### PR TITLE
remove src folder from npm pack output

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "ResizeObserver - Based on the official draft specification",
   "main": "./lib/ResizeObserver.js",
   "files": [
-    "lib/**/*.{js,ts}",
-    "src/**/*.ts"
+    "lib/**/*.{js,ts}"
   ],
   "scripts": {
     "build": "rm -rf lib && tsc",


### PR DESCRIPTION
`src` folder isn't need in npm pack output as definition files are provided for TypeScript