### PR TITLE
Calculate and dispatch notifications in the correct slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,23 @@ This allows for greater idle time, when the application itself is idle.
 - Canvas rendering (including HDPI).
 - Many other things!
 
+## Features
+
+- Inbuilt resize loop protection.
+- Supports pseudo classes `:hover`, `:active` and `:focus`.
+- Supports transitions and animations, including infinite and long-running.
+- Includes support for latest draft spec - observing different box sizes.
+- Polls only when required, then shuts down automatically, reducing CPU usage.
+- No notification delay - Notifications are batched and delivered immediately, before the next paint.
 
 ## Limitations
 
 - No support for **IE10** and below. **IE11** is supported.
-- Dynamic stylesheet changes may not be noticed and updates will occur on the next interaction.
+- Dynamic stylesheet changes may not be noticed.*
+- Transitions with initial delays cannot be detected.*
+- Animations and transitions with long periods of no change, will not be detected.*
+
+\* If other interaction occurs, changes will be detected.
 
 
 ## TypeScript support

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ This allows for greater idle time, when the application itself is idle.
 - Inbuilt resize loop protection.
 - Supports pseudo classes `:hover`, `:active` and `:focus`.
 - Supports transitions and animations, including infinite and long-running.
+- Detects changes which occur during animation frame.
 - Includes support for latest draft spec - observing different box sizes.
 - Polls only when required, then shuts down automatically, reducing CPU usage.
 - No notification delay - Notifications are batched and delivered immediately, before the next paint.

--- a/src/utils/scheduler.ts
+++ b/src/utils/scheduler.ts
@@ -19,6 +19,9 @@ const events = [
   'focus'
 ];
 
+// Keep original reference of raf to use later
+const raf = window.requestAnimationFrame;
+
 /**
  * Debounces events and processes
  * on the next animation frame.
@@ -26,7 +29,7 @@ const events = [
 let frameId: number;
 const run = (frames: number): void => {
   cancelAnimationFrame(frameId);
-  frameId = requestAnimationFrame(() => {
+  frameId = raf(() => {
     // Have any changes happened?
     if (process()) {
       run(60);
@@ -41,6 +44,13 @@ const run = (frames: number): void => {
 // Default sheduler
 // Runs checks on current and next frame
 const schedule = (): void => run(1);
+
+// Override raf to make sure calculations are performed after any changes may occur.
+window.requestAnimationFrame = function (callback) {
+  const id = raf(callback); // Callback should run first
+  schedule(); // Reschedule observation checks to run afterwards
+  return id;
+}
 
 // Listen to events
 events.forEach(name => window.addEventListener(name, schedule, true));

--- a/test/resize-observer-basic.test.ts
+++ b/test/resize-observer-basic.test.ts
@@ -272,4 +272,15 @@ describe('Basics', () => {
     ro.observe(el);
   })
 
+  test('Calculations should be run after all other raf callbacks have been fired.', (done) => {
+    ro = new ResizeObserver((entries) => {
+      expect(entries[0].contentRect.width).toBe(2000);
+      done();
+    });
+    ro.observe(el);
+    requestAnimationFrame(() => {
+      el.style.width = '2000px';
+    });
+  })
+
 })


### PR DESCRIPTION
This hooks into the native `requestAnimationFrame`, allowing the library to reschedule its next calculations after all other RAFs have completed. This allows notifications to be dispatched at the correct time.