### PR TITLE
Change Default Exports to Not Be Inline with Class Definitions

### DIFF
--- a/src/ResizeObserver.ts
+++ b/src/ResizeObserver.ts
@@ -9,7 +9,7 @@ const DPPB = ResizeObserverBoxOptions.DEVICE_PIXEL_BORDER_BOX;
 /**
  * https://drafts.csswg.org/resize-observer-1/#resize-observer-interface
  */
-export default class ResizeObserver {
+class ResizeObserver {
 
   public constructor (callback: ResizeObserverCallback) {
     if (arguments.length === 0) {
@@ -53,5 +53,5 @@ export default class ResizeObserver {
   }
 
 }
-
+export default ResizeObserver;
 export { ResizeObserver };

--- a/src/ResizeObserverController.ts
+++ b/src/ResizeObserverController.ts
@@ -91,5 +91,5 @@ class ResizeObserverController {
     }
   }
 }
-export default ResizeObserverController;
+
 export { ResizeObserverController, resizeObservers, process };

--- a/src/ResizeObserverController.ts
+++ b/src/ResizeObserverController.ts
@@ -52,7 +52,7 @@ const process = (): boolean => {
 /**
  * Used as an interface for connecting resize observers.
  */
-export default class ResizeObserverController {
+class ResizeObserverController {
   // Connects an observer to the controller.
   public static connect (resizeObserver: ResizeObserver, callback: ResizeObserverCallback): void {
     const detail = new ResizeObserverDetail(resizeObserver, callback);
@@ -91,5 +91,5 @@ export default class ResizeObserverController {
     }
   }
 }
-
+export default ResizeObserverController;
 export { ResizeObserverController, resizeObservers, process };

--- a/src/ResizeObserverOptions.ts
+++ b/src/ResizeObserverOptions.ts
@@ -3,11 +3,12 @@ import { ResizeObserverBoxOptions } from './ResizeObserverBoxOptions';
 /**
  * Options to be given to the resize observer,
  * when oberving a new element.
- * 
+ *
  * https://drafts.csswg.org/resize-observer-1/#dictdef-resizeobserveroptions
  */
-export default interface ResizeObserverOptions {
+interface ResizeObserverOptions {
   box: ResizeObserverBoxOptions | undefined;
 }
 
+export default ResizeObserverOptions;
 export { ResizeObserverOptions };

--- a/src/ResizeObserverOptions.ts
+++ b/src/ResizeObserverOptions.ts
@@ -10,5 +10,4 @@ interface ResizeObserverOptions {
   box: ResizeObserverBoxOptions | undefined;
 }
 
-export default ResizeObserverOptions;
 export { ResizeObserverOptions };


### PR DESCRIPTION
This appears to break webpack bundling for some build systems.