### PR TITLE
v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 ![](https://img.shields.io/bundlephobia/minzip/@juggle/resize-observer.svg?colorB=%233399ff&style=for-the-badge)
 ![](https://img.shields.io/npm/l/@juggle/resize-observer.svg?colorB=%233399ff&style=for-the-badge)
 
-A minimal library which polyfills the **ResizeObserver** API and is entirely based on the latest [Draft Specification](https://drafts.csswg.org/resize-observer-1/). Essentially, it detects when an element's size changes, allowing you to deal with it!
+A minimal library which polyfills the **ResizeObserver** API and is entirely based on the latest [Draft Specification](https://drafts.csswg.org/resize-observer-1/).
 
-Check out the [Box Demo](https://codepen.io/trem/full/VgEXgP) and [Animation Demo](https://codesandbox.io/embed/myqzvpmmy9?hidenavigation=1&module=%2Fsrc%2Findex.js&view=preview)
+It immediately detects when an element resizes and provides accurate sizing information back to the handler. Check out the [Example Playground](juggle.studio/resize-observer) for more information on usage and performance.
 
 > **Warning:**<br/>
 > The latest Resize Observer specification is not yet finalised and is subject to change.
@@ -39,35 +39,36 @@ import ResizeObserver from '@juggle/resize-observer';
 const ro = new ResizeObserver((entries, observer) => {
   console.log('Elements resized:', entries.length);
   entries.forEach((entry, index) => {
-    const { inline, block } = entry.contentBox;
-    console.log(`Element ${index + 1}:`, `${inline}x${block}`);
+    const { inlineSize, blockSize } = entry.contentBoxSize;
+    console.log(`Element ${index + 1}:`, `${inlineSize}x${blockSize}`);
   });
 });
 
-const els = docuent.querySelectorAll('.resizes');
+const els = document.querySelectorAll('.resizes');
 [...els].forEach(el => ro.observe(el)); // Watch multiple!
 ```
 
 ## Watching different box sizes
 
-The latest standards allow for watching different box sizes. The box size option can be specified when observing an element. Options inlcude `border-box` and `content-box` (default).
+The latest standards allow for watching different box sizes. The box size option can be specified when observing an element. Options include `border-box` and `content-box` (default).
 ``` js
 import ResizeObserver from '@juggle/resize-observer';
 
 const ro = new ResizeObserver((entries, observer) => {
   console.log('Elements resized:', entries.length);
   entries.forEach((entry, index) => {
-    const { inline, block } = entry.borderBox;
-    console.log(`Element ${index + 1}:`, `${inline}x${block}`);
+    const { inlineSize, blockSize } = entry.borderBoxSize;
+    console.log(`Element ${index + 1}:`, `${inlineSize}x${blockSize}`);
   });
 });
 
+// Watch border-box
 const observerOptions = {
   box: 'border-box'
 };
 
-const els = docuent.querySelectorAll('.resizes');
-[...els].forEach(el => ro.observe(el, observerOptions)); // Watch multiple!
+const els = document.querySelectorAll('.resizes');
+[...els].forEach(el => ro.observe(el, observerOptions));
 ```
 
 ## Using the legacy version (`contentRect`)
@@ -85,8 +86,8 @@ const ro = new ResizeObserver((entries, observer) => {
   });
 });
 
-const els = docuent.querySelectorAll('.resizes');
-[...els].forEach(el => ro.observe(el)); // Watch multiple!
+const els = document.querySelectorAll('.resizes');
+[...els].forEach(el => ro.observe(el));
 ```
 
 > **Warning:**<br/>
@@ -95,7 +96,7 @@ const els = docuent.querySelectorAll('.resizes');
 
 ## Switching between native and polyfilled versions
 
-You can check to see if the native version is available and switch between this and the polyfill to improve porformance on browsers with native support.
+You can check to see if the native version is available and switch between this and the polyfill to improve performance on browsers with native support.
 
 ``` js
 import { ResizeObserver as Polyfill } from '@juggle/resize-observer';
@@ -110,6 +111,7 @@ const ro = new ResizeObserver((entries, observer) => {
 
 > **Warning:**<br/>
 > Browsers with native support may be behind on the latest specification.
+> Use `entry.contentRect` when switching between native and polyfilled versions.
 
 
 ## Resize loop detection
@@ -135,7 +137,7 @@ ro.observe(document.body);
 ```
 
 ## Notification Schedule
-Notifications are scheduled after all other changes have occured and all other animation callbacks have been called. This allows the observer callback to get the most accurate size of an element, as no other changes should occur in the same frame.
+Notifications are scheduled after all other changes have occurred and all other animation callbacks have been called. This allows the observer callback to get the most accurate size of an element, as no other changes should occur in the same frame.
 
 ![resize observer notification schedule](https://user-images.githubusercontent.com/1519516/52825568-20433500-30b5-11e9-9854-4cee13a09a7d.jpg)
 
@@ -157,7 +159,7 @@ This allows for greater idle time, when the application itself is idle.
 - Making 3rd party libraries more responsive. e.g. charts and grids.
 - Locking scroll position to the bottom of elements - useful for chat windows and logs.
 - Resizing iframes to match their content.
-- Canvas rendering (including HDPI).
+- Canvas rendering.
 - Many other things!
 
 
@@ -174,7 +176,7 @@ This allows for greater idle time, when the application itself is idle.
 
 ## Limitations
 
-- No support for **IE10** and below. **IE11** is supported.
+- No support for **IE10** and below. **IE11** is supported, when bundled and transpiled into ES5.
 - Dynamic stylesheet changes may not be noticed.*
 - Transitions with initial delays cannot be detected.*
 - Animations and transitions with long periods of no change, will not be detected.*
@@ -197,4 +199,4 @@ This allows for greater idle time, when the application itself is idle.
 
 ## TypeScript support
 
-This library is written in TypeScript, however, it's compiled into JavaScript during release. Definition files are included in the package and should be picked up automatically to re-enable support in TypeScript projects.
+This library is written in TypeScript and contains all definition files for support in TypeScript applications.

--- a/README.md
+++ b/README.md
@@ -7,15 +7,11 @@
 
 A minimal library which polyfills the **ResizeObserver** API and is entirely based on the latest [Draft Specification](https://drafts.csswg.org/resize-observer-1/).
 
-<<<<<<< HEAD
 It immediately detects when an element resizes and provides accurate sizing information back to the handler. Check out the [Example Playground](juggle.studio/resize-observer) for more information on usage and performance.
 
 > **Warning:**<br/>
 > The latest Resize Observer specification is not yet finalised and is subject to change.
 > Any drastic changes to the specification will bump the major version of this library, as there will likely be breaking changes.
-=======
-Check out the [Box Demo](https://codesandbox.io/embed/l2vow0z6lq?hidenavigation=1&module=%2Fsrc%2Findex.js&view=preview) and [Animation Demo](https://codesandbox.io/embed/myqzvpmmy9?hidenavigation=1&module=%2Fsrc%2Findex.js&view=preview)
->>>>>>> master
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ A minimal library which polyfills the **ResizeObserver** API and is entirely bas
 
 Check out the [Box Demo](https://codepen.io/trem/full/VgEXgP) and [Animation Demo](https://codesandbox.io/embed/myqzvpmmy9?hidenavigation=1&module=%2Fsrc%2Findex.js&view=preview)
 
+> **Warning:**<br/>
+> The latest Resize Observer specification is not yet finalised and is subject to change.
+> Any drastic changes to the specification will bump the major version of this library, as there will likely be breaking changes.
+
 
 ## Installation
 ``` shell
@@ -35,8 +39,8 @@ import ResizeObserver from '@juggle/resize-observer';
 const ro = new ResizeObserver((entries, observer) => {
   console.log('Elements resized:', entries.length);
   entries.forEach((entry, index) => {
-    const { width, height } = entry.contentRect;
-    console.log(`Element ${index + 1}:`, `${width}x${height}`);
+    const { inline, block } = entry.contentBox;
+    console.log(`Element ${index + 1}:`, `${inline}x${block}`);
   });
 });
 
@@ -46,17 +50,15 @@ const els = docuent.querySelectorAll('.resizes');
 
 ## Watching different box sizes
 
-The latest standards allow for watching different box sizes. The box size option can be specified when observing an element. Options inlcude `border-box`, `content-box`, `scroll-box`, `device-pixel-border-box`.
-
-`device-pixel-border-box` can only be used on `canvas` elements.
+The latest standards allow for watching different box sizes. The box size option can be specified when observing an element. Options inlcude `border-box` and `content-box` (default).
 ``` js
 import ResizeObserver from '@juggle/resize-observer';
 
 const ro = new ResizeObserver((entries, observer) => {
   console.log('Elements resized:', entries.length);
   entries.forEach((entry, index) => {
-    const { inlineSize, blockSize } = entry.borderBoxSize;
-    console.log(`Element ${index + 1}:`, `${inlineSize}x${blockSize}`);
+    const { inline, block } = entry.borderBox;
+    console.log(`Element ${index + 1}:`, `${inline}x${block}`);
   });
 });
 
@@ -68,8 +70,27 @@ const els = docuent.querySelectorAll('.resizes');
 [...els].forEach(el => ro.observe(el, observerOptions)); // Watch multiple!
 ```
 
-> **Warning:** The latest Resize Observer specification is not yet finalised and is subject to change.
-> Any drastic changes to the specification will bump the major version of this library, as there will likely be breaking changes.
+## Using the legacy version (`contentRect`)
+
+Early versions of the API return a `contentRect`. This is still made available for backwards compatibility.
+
+``` js
+import ResizeObserver from '@juggle/resize-observer';
+
+const ro = new ResizeObserver((entries, observer) => {
+  console.log('Elements resized:', entries.length);
+  entries.forEach((entry, index) => {
+    const { width, height } = entry.contentRect;
+    console.log(`Element ${index + 1}:`, `${width}x${height}`);
+  });
+});
+
+const els = docuent.querySelectorAll('.resizes');
+[...els].forEach(el => ro.observe(el)); // Watch multiple!
+```
+
+> **Warning:**<br/>
+> This is a **deprecated** feature and will possibly be removed in later versions.
 
 
 ## Switching between native and polyfilled versions
@@ -77,9 +98,9 @@ const els = docuent.querySelectorAll('.resizes');
 You can check to see if the native version is available and switch between this and the polyfill to improve porformance on browsers with native support.
 
 ``` js
-import ResizeObserverPolyfill from '@juggle/resize-observer';
+import { ResizeObserver as Polyfill } from '@juggle/resize-observer';
 
-const ResizeObserver = window.ResizeObserver || ResizeObserverPolyfill;
+const ResizeObserver = window.ResizeObserver || Polyfill;
 
 // Uses native or polyfill, depending on browser support
 const ro = new ResizeObserver((entries, observer) => {
@@ -87,7 +108,8 @@ const ro = new ResizeObserver((entries, observer) => {
 });
 ```
 
-> **Warning:** Browsers with native support may be behind on the latest specification.
+> **Warning:**<br/>
+> Browsers with native support may be behind on the latest specification.
 
 
 ## Resize loop detection
@@ -134,6 +156,7 @@ This allows for greater idle time, when the application itself is idle.
 - Creating self-aware, responsive Web Components.
 - Making 3rd party libraries more responsive. e.g. charts and grids.
 - Locking scroll position to the bottom of elements - useful for chat windows and logs.
+- Resizing iframes to match their content.
 - Canvas rendering (including HDPI).
 - Many other things!
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@juggle/resize-observer",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juggle/resize-observer",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "Polyfills the ResizeObserver API and supports box size options from the latest spec",
   "main": "./lib/ResizeObserver.js",
   "files": [

--- a/src/ResizeObservation.ts
+++ b/src/ResizeObservation.ts
@@ -9,25 +9,22 @@ class ResizeObservation {
 
   public target: Element;
   public observedBox: ResizeObserverBoxOptions;
-  public lastReportedSize: ResizeObserverSize[];
+  public lastReportedSize: ResizeObserverSize;
 
   public constructor (target: Element, observedBox?: ResizeObserverBoxOptions) {
     this.target = target;
     this.observedBox = observedBox || ResizeObserverBoxOptions.CONTENT_BOX;
-    this.lastReportedSize = [{
-      inline: 0,
-      block: 0
-    }]
+    this.lastReportedSize = {
+      inlineSize: 0,
+      blockSize: 0
+    }
   }
 
   public isActive (): boolean {
+    const last = this.lastReportedSize;
     const size = calculateBoxSize(this.target, this.observedBox);
-    for (let i = 0; i < size.length; i += 1) {
-      const a = size[i];
-      const b = this.lastReportedSize[i];
-      if (!(a && b && a.inline === b.inline && a.block === b.block)) {
-        return true;
-      }
+    if (last.inlineSize !== size.inlineSize || last.blockSize !== size.blockSize) {
+      return true;
     }
     return false;
   }

--- a/src/ResizeObservation.ts
+++ b/src/ResizeObservation.ts
@@ -9,21 +9,27 @@ class ResizeObservation {
 
   public target: Element;
   public observedBox: ResizeObserverBoxOptions;
-  public lastReportedSize: ResizeObserverSize;
+  public lastReportedSize: ResizeObserverSize[];
 
   public constructor (target: Element, observedBox?: ResizeObserverBoxOptions) {
     this.target = target;
     this.observedBox = observedBox || ResizeObserverBoxOptions.CONTENT_BOX;
-    this.lastReportedSize = {
-      inlineSize: 0,
-      blockSize: 0
-    }
+    this.lastReportedSize = [{
+      inline: 0,
+      block: 0
+    }]
   }
 
   public isActive (): boolean {
     const size = calculateBoxSize(this.target, this.observedBox);
-    return this.lastReportedSize.inlineSize !== size.inlineSize
-      || this.lastReportedSize.blockSize !== size.blockSize;
+    for (let i = 0; i < size.length; i += 1) {
+      const a = size[i];
+      const b = this.lastReportedSize[i];
+      if (!(a && b && a.inline === b.inline && a.block === b.block)) {
+        return true;
+      }
+    }
+    return false;
   }
 
 }

--- a/src/ResizeObserver.ts
+++ b/src/ResizeObserver.ts
@@ -1,10 +1,7 @@
 import { ResizeObserverController } from './ResizeObserverController';
 import { ResizeObserverCallback } from './ResizeObserverCallback';
-import { ResizeObserverBoxOptions } from './ResizeObserverBoxOptions';
 import { ResizeObserverOptions } from './ResizeObserverOptions';
 import { POLYFILL_CONSOLE_OUTPUT } from './utils/prettify';
-
-const DPPB = ResizeObserverBoxOptions.DEVICE_PIXEL_BORDER_BOX;
 
 /**
  * https://drafts.csswg.org/resize-observer-1/#resize-observer-interface
@@ -27,9 +24,6 @@ class ResizeObserver {
     }
     if (target instanceof Element === false) {
       throw new TypeError(`Failed to execute 'observe' on 'ResizeObserver': parameter 1 is not of type 'Element`);
-    }
-    if (options && options.box === DPPB && target.tagName !== 'CANVAS') {
-      throw new Error(`Can only watch ${options.box} on canvas elements.`);
     }
     ResizeObserverController.observe(this, target, options);
   }

--- a/src/ResizeObserverBoxOptions.ts
+++ b/src/ResizeObserverBoxOptions.ts
@@ -5,9 +5,7 @@
  */
 enum ResizeObserverBoxOptions {
   BORDER_BOX = 'border-box',
-  CONTENT_BOX = 'content-box',
-  SCROLL_BOX = 'scroll-box',
-  DEVICE_PIXEL_BORDER_BOX = 'device-pixel-border-box'
+  CONTENT_BOX = 'content-box'
 }
 
 export { ResizeObserverBoxOptions };

--- a/src/ResizeObserverEntry.ts
+++ b/src/ResizeObserverEntry.ts
@@ -8,18 +8,14 @@ import { calculateBoxSizes } from './algorithms/calculateBoxSize';
 class ResizeObserverEntry {
   public target: Element;
   public contentRect: DOMRectReadOnly;
-  public borderBoxSize: ResizeObserverSize;
-  public contentSize: ResizeObserverSize;
-  public scrollSize: ResizeObserverSize;
-  public devicePixelBorderBoxSize: ResizeObserverSize;
+  public borderBox: ResizeObserverSize[];
+  public contentBox: ResizeObserverSize[];
   public constructor (target: Element) {
     const boxes = calculateBoxSizes(target);
     this.target = target;
     this.contentRect = boxes.contentRect;
-    this.borderBoxSize = boxes.borderBoxSize;
-    this.contentSize = boxes.contentBoxSize;
-    this.scrollSize = boxes.scrollBoxSize;
-    this.devicePixelBorderBoxSize = boxes.devicePixelBorderBoxSize;
+    this.borderBox = boxes.borderBox;
+    this.contentBox = boxes.contentBox;
   }
 }
 

--- a/src/ResizeObserverEntry.ts
+++ b/src/ResizeObserverEntry.ts
@@ -8,14 +8,14 @@ import { calculateBoxSizes } from './algorithms/calculateBoxSize';
 class ResizeObserverEntry {
   public target: Element;
   public contentRect: DOMRectReadOnly;
-  public borderBox: ResizeObserverSize[];
-  public contentBox: ResizeObserverSize[];
+  public borderBoxSize: ResizeObserverSize;
+  public contentBoxSize: ResizeObserverSize;
   public constructor (target: Element) {
     const boxes = calculateBoxSizes(target);
     this.target = target;
     this.contentRect = boxes.contentRect;
-    this.borderBox = boxes.borderBox;
-    this.contentBox = boxes.contentBox;
+    this.borderBoxSize = boxes.borderBoxSize;
+    this.contentBoxSize = boxes.contentBoxSize;
   }
 }
 

--- a/src/ResizeObserverSize.ts
+++ b/src/ResizeObserverSize.ts
@@ -4,8 +4,8 @@
  * https://drafts.csswg.org/resize-observer-1/#resizeobserversize 
  */
 interface ResizeObserverSize {
-  readonly inline: number;
-  readonly block: number;
+  readonly inlineSize: number;
+  readonly blockSize: number;
 }
 
 export { ResizeObserverSize };

--- a/src/ResizeObserverSize.ts
+++ b/src/ResizeObserverSize.ts
@@ -4,8 +4,8 @@
  * https://drafts.csswg.org/resize-observer-1/#resizeobserversize 
  */
 interface ResizeObserverSize {
-  readonly inlineSize: number;
-  readonly blockSize: number;
+  readonly inline: number;
+  readonly block: number;
 }
 
 export { ResizeObserverSize };

--- a/src/algorithms/calculateBoxSize.ts
+++ b/src/algorithms/calculateBoxSize.ts
@@ -4,8 +4,8 @@ import { DOMRectReadOnly } from '../DOMRectReadOnly';
 import { isSVG, isHidden } from '../utils/element';
 
 interface ResizeObserverSizeCollection {
-  borderBox: ResizeObserverSize[];
-  contentBox: ResizeObserverSize[];
+  borderBoxSize: ResizeObserverSize;
+  contentBoxSize: ResizeObserverSize;
   contentRect: DOMRectReadOnly;
 }
 
@@ -15,14 +15,14 @@ const IE = (/msie|trident/i).test(navigator.userAgent);
 const parseDimension = (pixel: string | null): number => parseFloat(pixel || '0');
 
 // Helper to generate and freeze a ResizeObserverSize
-const size = (inline: number = 0, block: number = 0): ResizeObserverSize => {
-  return Object.freeze({ inline, block });
+const size = (inlineSize: number = 0, blockSize: number = 0): ResizeObserverSize => {
+  return Object.freeze({ inlineSize, blockSize });
 }
 
 // Return this when targets are hidden
 const zeroBoxes = Object.freeze({
-  borderBox: [size()],
-  contentBox: [size()],
+  borderBoxSize: size(),
+  contentBoxSize: size(),
   contentRect: new DOMRectReadOnly(0, 0, 0, 0)
 })
 
@@ -77,8 +77,8 @@ const calculateBoxSizes = (target: Element): ResizeObserverSizeCollection => {
   const borderBoxHeight = contentHeight + verticalPadding + horizontalScrollbarThickness + verticalBorderArea;
 
   const boxes = Object.freeze({
-    borderBox: [size(borderBoxWidth, borderBoxHeight)],
-    contentBox: [size(contentWidth, contentHeight)],
+    borderBoxSize: size(borderBoxWidth, borderBoxHeight),
+    contentBoxSize: size(contentWidth, contentHeight),
     contentRect: new DOMRectReadOnly(paddingLeft, paddingTop, contentWidth, contentHeight)
   });
 
@@ -92,9 +92,9 @@ const calculateBoxSizes = (target: Element): ResizeObserverSizeCollection => {
  * 
  * https://drafts.csswg.org/resize-observer-1/#calculate-box-size
  */
-const calculateBoxSize = (target: Element, observedBox: ResizeObserverBoxOptions): ResizeObserverSize[] => {
-  const { borderBox, contentBox } = calculateBoxSizes(target);
-  return observedBox === ResizeObserverBoxOptions.BORDER_BOX ? borderBox : contentBox;
+const calculateBoxSize = (target: Element, observedBox: ResizeObserverBoxOptions): ResizeObserverSize => {
+  const { borderBoxSize, contentBoxSize } = calculateBoxSizes(target);
+  return observedBox === ResizeObserverBoxOptions.BORDER_BOX ? borderBoxSize : contentBoxSize;
 };
 
 export { calculateBoxSize, calculateBoxSizes, cache };

--- a/test/resize-observer-box-sizes.test.ts
+++ b/test/resize-observer-box-sizes.test.ts
@@ -9,10 +9,10 @@ describe('Box Options', () => {
   const DEFAULT_WIDTH = 100;
   const DEFAULT_HEIGHT = 200;
 
-  const initialBox = {
-    inlineSize: DEFAULT_WIDTH,
-    blockSize: DEFAULT_HEIGHT
-  };
+  const initialBox = [{
+    inline: DEFAULT_WIDTH,
+    block: DEFAULT_HEIGHT
+  }];
 
   let el: HTMLElement;
   let ro: ResizeObserver;
@@ -43,13 +43,8 @@ describe('Box Options', () => {
           width: DEFAULT_WIDTH,
           height: DEFAULT_HEIGHT
         })
-        expect(entries[0].borderBoxSize).toMatchObject(initialBox);
-        expect(entries[0].contentSize).toMatchObject(initialBox);
-        expect(entries[0].scrollSize).toMatchObject(initialBox);
-        expect(entries[0].devicePixelBorderBoxSize).toMatchObject({
-          inlineSize: initialBox.inlineSize * 5,
-          blockSize: initialBox.blockSize * 5
-        })
+        expect(entries[0].borderBox).toMatchObject(initialBox);
+        expect(entries[0].contentBox).toMatchObject(initialBox);
         done();
       })
       ro.observe(el, {
@@ -71,13 +66,8 @@ describe('Box Options', () => {
           width: DEFAULT_WIDTH,
           height: DEFAULT_HEIGHT
         })
-        expect(entries[0].borderBoxSize).toMatchObject(initialBox);
-        expect(entries[0].contentSize).toMatchObject(initialBox);
-        expect(entries[0].scrollSize).toMatchObject(initialBox);
-        expect(entries[0].devicePixelBorderBoxSize).toMatchObject({
-          inlineSize: initialBox.inlineSize * 5,
-          blockSize: initialBox.blockSize * 5
-        })
+        expect(entries[0].borderBox).toMatchObject(initialBox);
+        expect(entries[0].contentBox).toMatchObject(initialBox);
         done();
       })
       ro.observe(el, {
@@ -96,22 +86,14 @@ describe('Box Options', () => {
           width: 300,
           height: 100
         })
-        expect(entries[0].borderBoxSize).toMatchObject({
-          inlineSize: 330,
-          blockSize: 130
-        })
-        expect(entries[0].contentSize).toMatchObject({
-          inlineSize: 300,
-          blockSize: 100
-        })
-        expect(entries[0].scrollSize).toMatchObject({
-          inlineSize: 320,
-          blockSize: 120
-        })
-        expect(entries[0].devicePixelBorderBoxSize).toMatchObject({
-          inlineSize: 330 * 5,
-          blockSize: 130 * 5
-        })
+        expect(entries[0].borderBox).toMatchObject([{
+          inline: 330,
+          block: 130
+        }])
+        expect(entries[0].contentBox).toMatchObject([{
+          inline: 300,
+          block: 100
+        }])
         done();
       })
       el.style.width = '300px';
@@ -121,72 +103,6 @@ describe('Box Options', () => {
       ro.observe(el, {
         box: 'border-box' as ResizeObserverBoxOptions
       })
-    })
-  })
-
-  describe('scroll-box', () => {
-    test('Should fire initial resize', (done) => {
-      ro = new ResizeObserver((entries, observer) => {
-        expect(entries).toHaveLength(1);
-        expect(entries[0].target).toBe(el);
-        expect(observer).toBe(ro);
-        expect(entries[0].contentRect).toMatchObject({
-          top: 0,
-          left: 0,
-          width: DEFAULT_WIDTH,
-          height: DEFAULT_HEIGHT
-        })
-        expect(entries[0].borderBoxSize).toMatchObject(initialBox);
-        expect(entries[0].contentSize).toMatchObject(initialBox);
-        expect(entries[0].scrollSize).toMatchObject(initialBox);
-        expect(entries[0].devicePixelBorderBoxSize).toMatchObject({
-          inlineSize: initialBox.inlineSize * 5,
-          blockSize: initialBox.blockSize * 5
-        })
-        done();
-      })
-      ro.observe(el, {
-        box: 'scroll-box' as ResizeObserverBoxOptions
-      })
-    })
-  })
-
-  describe('device-pixel-border-box', () => {
-    test('Should fire initial resize', (done) => {
-      const canvas = document.createElement('CANVAS');
-      ro = new ResizeObserver((entries, observer) => {
-        expect(entries).toHaveLength(1);
-        expect(entries[0].target).toBe(canvas);
-        expect(observer).toBe(ro);
-        expect(entries[0].contentRect).toMatchObject({
-          top: 0,
-          left: 0,
-          width: DEFAULT_WIDTH,
-          height: DEFAULT_HEIGHT
-        })
-        expect(entries[0].borderBoxSize).toMatchObject(initialBox);
-        expect(entries[0].contentSize).toMatchObject(initialBox);
-        expect(entries[0].scrollSize).toMatchObject(initialBox);
-        expect(entries[0].devicePixelBorderBoxSize).toMatchObject({
-          inlineSize: initialBox.inlineSize * 5,
-          blockSize: initialBox.blockSize * 5
-        })
-        done();
-      })
-      canvas.style.width = DEFAULT_WIDTH + 'px';
-      canvas.style.height = DEFAULT_HEIGHT + 'px';
-      document.body.appendChild(canvas);
-      ro.observe(canvas, {
-        box: 'device-pixel-border-box' as ResizeObserverBoxOptions
-      })
-    })
-    it('Should throw error when element is not of type canvas', () => {
-      expect(() => {
-        ro = new ResizeObserver(() => {})
-        ro.observe(el, {
-          box: 'device-pixel-border-box' as ResizeObserverBoxOptions
-        })
-      }).toThrow('Can only watch device-pixel-border-box on canvas elements.');
     })
   })
 

--- a/test/resize-observer-box-sizes.test.ts
+++ b/test/resize-observer-box-sizes.test.ts
@@ -9,10 +9,10 @@ describe('Box Options', () => {
   const DEFAULT_WIDTH = 100;
   const DEFAULT_HEIGHT = 200;
 
-  const initialBox = [{
-    inline: DEFAULT_WIDTH,
-    block: DEFAULT_HEIGHT
-  }];
+  const initialBox = {
+    inlineSize: DEFAULT_WIDTH,
+    blockSize: DEFAULT_HEIGHT
+  };
 
   let el: HTMLElement;
   let ro: ResizeObserver;
@@ -43,8 +43,8 @@ describe('Box Options', () => {
           width: DEFAULT_WIDTH,
           height: DEFAULT_HEIGHT
         })
-        expect(entries[0].borderBox).toMatchObject(initialBox);
-        expect(entries[0].contentBox).toMatchObject(initialBox);
+        expect(entries[0].borderBoxSize).toMatchObject(initialBox);
+        expect(entries[0].contentBoxSize).toMatchObject(initialBox);
         done();
       })
       ro.observe(el, {
@@ -66,8 +66,8 @@ describe('Box Options', () => {
           width: DEFAULT_WIDTH,
           height: DEFAULT_HEIGHT
         })
-        expect(entries[0].borderBox).toMatchObject(initialBox);
-        expect(entries[0].contentBox).toMatchObject(initialBox);
+        expect(entries[0].borderBoxSize).toMatchObject(initialBox);
+        expect(entries[0].contentBoxSize).toMatchObject(initialBox);
         done();
       })
       ro.observe(el, {
@@ -86,14 +86,14 @@ describe('Box Options', () => {
           width: 300,
           height: 100
         })
-        expect(entries[0].borderBox).toMatchObject([{
-          inline: 330,
-          block: 130
-        }])
-        expect(entries[0].contentBox).toMatchObject([{
-          inline: 300,
-          block: 100
-        }])
+        expect(entries[0].borderBoxSize).toMatchObject({
+          inlineSize: 330,
+          blockSize: 130
+        })
+        expect(entries[0].contentBoxSize).toMatchObject({
+          inlineSize: 300,
+          blockSize: 100
+        })
         done();
       })
       el.style.width = '300px';


### PR DESCRIPTION
This major version upgrade will update the library to cover the new shape of the `ResizeObserverEntry`. Need to also pay close attention to https://github.com/w3c/csswg-drafts/projects/10.

``` js
entry = {
  target: <element>,
  contentRect: { /* v1 backwards compat */ },
  borderBox: null,
  contentBox: [{
    inline: 300,
    block: 200
  }]
}
```

**Confirmed changes:**
- [x] Remove `scrollBox` support.
- [x] Remove `devicePixelBorderBox` support.
- [x] ~~Return null for unobserved boxes.~~
- [x] ~~Rename `borderBoxSize` to `borderBox`.~~
- [x] ~~Rename `contentSize` to `contentBox`.~~
- [x] ~~Rename `inlineSize` to `inline`.~~
- [x] ~~Rename `blockSize` to `block`.~~
- [x] Update internal names for box sizes.
- [x] Remove canvas checks for `device-pixel-border-box`.
- [x] Return values as array to support fragments in the future

**Needs confirmation:**
- [x] ~~Create new key based on element and options?~~
- [x] ~~Observing the same element multiple times, with different options, is supported?~~

**Additional updates:**
- [x] ~~Update readme examples and link to v1 version of readme~~
- [x] Updated all demos to use v2

**Potential upcoming changes:**
- Fragmentation of element boxes (unlikely to be anytime soon).
- ~~Add offset information to entry.~~