### PR TITLE
Fix transition catch

### DIFF
--- a/src/utils/scheduler.ts
+++ b/src/utils/scheduler.ts
@@ -70,9 +70,6 @@ class Scheduler {
   }
 
   public run (frames: number): void {
-    if (resizeObserverSlot.has(this)) {
-      return;
-    }
     const scheduler = this;
     resizeObserverSlot.set(this, function ResizeObserver () {
       let elementsHaveResized = false;

--- a/src/utils/scheduler.ts
+++ b/src/utils/scheduler.ts
@@ -1,7 +1,7 @@
 import { process } from '../ResizeObserverController';
 import { prettifyConsoleOutput } from './prettify';
 
-const CATCH_FRAMES = 5;
+const CATCH_FRAMES = 60 / 5; // Fifth of a second
 
 // Keep original reference of raf to use later
 const requestAnimationFrame = window.requestAnimationFrame;

--- a/test/resize-observer-basic.test.ts
+++ b/test/resize-observer-basic.test.ts
@@ -503,9 +503,22 @@ describe('Basics', () => {
     ro.observe(el);
   })
 
-  test.skip('Scheduler should start and stop itself correctly.', () => {
-    // Skip this for now as it's very hard to test.
-    // Keep this here as a reminder.
+  test('Scheduler should start and stop itself correctly.', (done) => {
+    // Stopped at start
+    expect(scheduler.stopped).toBe(true);
+    ro = new ResizeObserver(() => {});
+    // Creating an observer should not start the scheduler
+    expect(scheduler.stopped).toBe(true);
+    ro.observe(el);
+    // Observering will trigger a schedule, however,
+    // it will not start listening for other changes untill
+    // the processing is complete
+    expect(scheduler.stopped).toBe(true);
+    // After ~1s the observer should stop polling and move back to events
+    setTimeout(() => {
+      expect(scheduler.stopped).toBe(false);
+      done();
+    }, 1500);
   })
 
   test('Scheduler should handle multiple starts and stops.', () => {


### PR DESCRIPTION
This removes codes which prevented the processing function to be rewritten. This meant that the additional catch frames were never used and running animations/transitions were never noticed.

Fixes #43 