### PR TITLE
[bugfix] set callback scope to be observer

### DIFF
--- a/src/algorithms/broadcastActiveObservations.ts
+++ b/src/algorithms/broadcastActiveObservations.ts
@@ -29,7 +29,10 @@ const broadcastActiveObservations = (): number => {
     })
     // Gather all entries before firing callbacks
     // otherwise entries may change in the same loop
-    callbacks.push(function resizeObserverCallback(): void { ro.callback(entries, ro.observer) });
+    callbacks.push(function resizeObserverCallback(): void {
+      // callback.this should be resize observer
+      ro.callback.call(ro.observer, entries, ro.observer)
+    });
     ro.activeTargets.splice(0, ro.activeTargets.length);
   })
   for (let callback of callbacks) {

--- a/test/resize-observer-basic.test.ts
+++ b/test/resize-observer-basic.test.ts
@@ -124,6 +124,14 @@ describe('Basics', (): void => {
     delay(done);
   })
 
+  test('Observer callback.this should be observer', (done): void => {
+    ro = new ResizeObserver(function (this: ResizeObserver): void {
+      expect(this).toBe(ro);
+      done();
+    })
+    ro.observe(el);
+  })
+
   test('Observer should fire initially when element has size and display', (done): void => {
     ro = new ResizeObserver((entries): void => {
       expect(entries).toHaveLength(1);


### PR DESCRIPTION
This sets the callback's scope to be the observer itself.

Closes #58 