### PR TITLE
[bugfix] do not skip inline svg elements

### DIFF
--- a/src/ResizeObservation.ts
+++ b/src/ResizeObservation.ts
@@ -1,10 +1,12 @@
 import { ResizeObserverSize } from './ResizeObserverSize';
 import { ResizeObserverBoxOptions } from './ResizeObserverBoxOptions';
 import { calculateBoxSize } from './algorithms/calculateBoxSize';
-import { isReplacedElement } from './utils/element';
+import { isSVG, isReplacedElement } from './utils/element';
 
 const skipNotifyOnElement = (target: Element): boolean => {
-  return !isReplacedElement(target) && getComputedStyle(target).display === 'inline';
+  return !isSVG(target)
+  && !isReplacedElement(target)
+  && getComputedStyle(target).display === 'inline';
 }
 
 /**


### PR DESCRIPTION
SVG elements which have `display:inline` should not be skipped as they are not instance of `HTMLElement`.