### PR TITLE
Create and use a single es5 output for dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 node_modules
 coverage
 lib
-main
 junit.xml
 .cache

--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "@juggle/resize-observer",
   "version": "2.0.3",
   "description": "Polyfills the ResizeObserver API and supports box size options from the latest spec",
-  "main": "./main/ResizeObserver.js",
+  "main": "./lib/ResizeObserver.js",
   "module": "./lib/ResizeObserver.js",
   "source": "./lib/ResizeObserver.js",
   "files": [
-    "{lib,main}/**/*.{js,ts}"
+    "lib/**/*.{js,ts}"
   ],
   "scripts": {
-    "build": "rm -rf lib main && tsc --build tsconfig.module.json && tsc --build tsconfig.main.json",
+    "build": "rm -rf lib && tsc",
     "build-docs": "rm -f docs/*.* && parcel build docs/src/index.html --out-dir docs --public-url ./",
     "ci-tests": "npm test -- --ci --runInBand && cat coverage/lcov.info | coveralls",
     "test": "npm run lint && jest --coverage",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "compilerOptions": {
+    "target": "es5",
+    "module": "es2015",
+    "outDir": "./lib",
     "rootDir": "./src",
     "declaration": true,
     "removeComments": true,

--- a/tsconfig.main.json
+++ b/tsconfig.main.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "target": "es5",
-    "module": "es2015",
-    "outDir": "./main",
-  }
-}

--- a/tsconfig.module.json
+++ b/tsconfig.module.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "target": "es2015",
-    "module": "es2015",
-    "outDir": "./lib",
-  }
-}


### PR DESCRIPTION
Revert back to previous es2015 modules, however, transpile the code.

Part of #39 