### PR TITLE
[bugfix] use safe global object to prevent issues in non-browser environments

### DIFF
--- a/src/algorithms/calculateBoxSize.ts
+++ b/src/algorithms/calculateBoxSize.ts
@@ -2,6 +2,7 @@ import { ResizeObserverBoxOptions } from '../ResizeObserverBoxOptions';
 import { ResizeObserverSize } from '../ResizeObserverSize';
 import { DOMRectReadOnly } from '../DOMRectReadOnly';
 import { isSVG, isHidden } from '../utils/element';
+import { global } from '../utils/global';
 
 interface ResizeObserverSizeCollection {
   borderBoxSize: ResizeObserverSize;
@@ -12,7 +13,7 @@ interface ResizeObserverSizeCollection {
 const cache = new Map();
 const scrollRegexp = /auto|scroll/;
 const verticalRegexp = /^tb|vertical/;
-const IE = (/msie|trident/i).test(navigator.userAgent);
+const IE = (/msie|trident/i).test(global.navigator && global.navigator.userAgent);
 const parseDimension = (pixel: string | null): number => parseFloat(pixel || '0');
 
 // Helper to generate and freeze a ResizeObserverSize

--- a/src/utils/global.ts
+++ b/src/utils/global.ts
@@ -1,0 +1,3 @@
+/* istanbul ignore next */
+const global = typeof window === 'undefined' ? this || {} : window;
+export { global }

--- a/src/utils/scheduler.ts
+++ b/src/utils/scheduler.ts
@@ -1,10 +1,11 @@
 import { process } from '../ResizeObserverController';
 import { prettifyConsoleOutput } from './prettify';
+import { global } from './global';
 
 const CATCH_FRAMES = 60 / 5; // Fifth of a second
 
 // Keep original reference of raf to use later
-const requestAnimationFrame = window.requestAnimationFrame;
+const requestAnimationFrame = global.requestAnimationFrame;
 
 const observerConfig = { attributes: true, characterData: true, childList: true, subtree: true };
 
@@ -103,24 +104,24 @@ class Scheduler {
   private observe (): void {
     const cb = (): void => this.observer && this.observer.observe(document.body, observerConfig);
     /* istanbul ignore next */
-    document.body ? cb() : window.addEventListener('DOMContentLoaded', cb);
+    document.body ? cb() : global.addEventListener('DOMContentLoaded', cb);
   }
 
   public start (): void {
     if (this.stopped) {
       this.stopped = false;
-      if ('MutationObserver' in window) {
+      if ('MutationObserver' in global) {
         this.observer = new MutationObserver(this.listener);
         this.observe();
       }
-      events.forEach((name): void => window.addEventListener(name, this.listener, true));
+      events.forEach((name): void => global.addEventListener(name, this.listener, true));
     }
   }
 
   public stop (): void {
     if (!this.stopped) {
       this.observer && this.observer.disconnect();
-      events.forEach((name): void => window.removeEventListener(name, this.listener, true));
+      events.forEach((name): void => global.removeEventListener(name, this.listener, true));
       this.stopped = true;
     }
   }
@@ -132,7 +133,7 @@ let rafIdBase = 0;
 // Override requestAnimationFrame to make sure
 // calculations are performed after any changes may occur.
 // * Is there another way to schedule without modifying the whole function?
-window.requestAnimationFrame = function (callback): number {
+global.requestAnimationFrame = function (callback): number {
   if (typeof callback !== 'function') {
     throw new Error('requestAnimationFrame expects 1 callback argument of type function.');
   }
@@ -143,10 +144,10 @@ window.requestAnimationFrame = function (callback): number {
 }
 // Override cancelAnimationFrame
 // as we need to handle custom removal
-window.cancelAnimationFrame = function (handle): void {
+global.cancelAnimationFrame = function (handle): void {
   rafSlot.delete(handle);
 }
-prettifyConsoleOutput(window.requestAnimationFrame);
-prettifyConsoleOutput(window.cancelAnimationFrame);
+prettifyConsoleOutput(global.requestAnimationFrame);
+prettifyConsoleOutput(global.cancelAnimationFrame);
 
 export { scheduler };


### PR DESCRIPTION
This removes the global usage of `window` and replaces with a safer object.
This allows the library to be loaded into non-browser environments, like node, and closes #73.