### PR TITLE
Avoid circular dependencies

### DIFF
--- a/src/ResizeObserverController.ts
+++ b/src/ResizeObserverController.ts
@@ -1,4 +1,4 @@
-import { scheduler } from './utils/scheduler';
+import { scheduler, updateCount } from './utils/scheduler';
 
 import { ResizeObserver } from './ResizeObserver';
 import { ResizeObservation } from './ResizeObservation';
@@ -6,21 +6,9 @@ import { ResizeObserverDetail } from './ResizeObserverDetail';
 import { ResizeObserverCallback } from './ResizeObserverCallback';
 import { ResizeObserverOptions } from './ResizeObserverOptions';
 
-import { hasActiveObservations } from './algorithms/hasActiveObservations';
-import { hasSkippedObservations } from './algorithms/hasSkippedObservations';
-import { deliverResizeLoopError } from './algorithms/deliverResizeLoopError';
-import { broadcastActiveObservations } from './algorithms/broadcastActiveObservations';
-import { gatherActiveObservationsAtDepth } from './algorithms/gatherActiveObservationsAtDepth';
+import { resizeObservers } from './utils/resizeObservers';
 
-const resizeObservers: ResizeObserverDetail[] = [];
-const observerMap = new Map();
-let watching = 0;
-
-const updateCount = (n: number): void => {
-  !watching && n > 0 && scheduler.start();
-  watching += n;
-  !watching && scheduler.stop();
-}
+const observerMap = new Map<ResizeObserver, ResizeObserverDetail>();
 
 // Helper to find the correct ResizeObservation, based on a target.
 const getObservationIndex = (observationTargets: ResizeObservation[], target: Element): number => {
@@ -30,23 +18,6 @@ const getObservationIndex = (observationTargets: ResizeObservation[], target: El
     }
   }
   return -1;
-}
-
-/**
- * Runs through the algorithms and
- * broadcasts and changes that are returned.
- */
-const process = (): boolean => {
-  let depth = 0;
-  gatherActiveObservationsAtDepth(depth);
-  while (hasActiveObservations()) {
-    depth = broadcastActiveObservations();
-    gatherActiveObservationsAtDepth(depth);
-  }
-  if (hasSkippedObservations()) {
-    deliverResizeLoopError();
-  }
-  return depth > 0;
 }
 
 /**
@@ -92,6 +63,4 @@ class ResizeObserverController {
   }
 }
 
-const isWatching = (): boolean => !!watching;
-
-export { ResizeObserverController, resizeObservers, process, isWatching };
+export { ResizeObserverController };

--- a/src/algorithms/broadcastActiveObservations.ts
+++ b/src/algorithms/broadcastActiveObservations.ts
@@ -1,4 +1,4 @@
-import { resizeObservers } from '../ResizeObserverController';
+import { resizeObservers } from '../utils/resizeObservers';
 import { ResizeObserverDetail } from '../ResizeObserverDetail';
 import { ResizeObserverEntry } from '../ResizeObserverEntry';
 import { ResizeObservation } from '../ResizeObservation';

--- a/src/algorithms/gatherActiveObservationsAtDepth.ts
+++ b/src/algorithms/gatherActiveObservationsAtDepth.ts
@@ -1,6 +1,6 @@
 import { ResizeObservation } from '../ResizeObservation';
 import { ResizeObserverDetail } from '../ResizeObserverDetail';
-import { resizeObservers } from '../ResizeObserverController';
+import { resizeObservers } from '../utils/resizeObservers';
 import { calculateDepthForNode } from './calculateDepthForNode';
 import { cache as sizeCache } from './calculateBoxSize';
 

--- a/src/algorithms/hasActiveObservations.ts
+++ b/src/algorithms/hasActiveObservations.ts
@@ -1,4 +1,4 @@
-import { resizeObservers } from '../ResizeObserverController';
+import { resizeObservers } from '../utils/resizeObservers';
 import { ResizeObserverDetail } from '../ResizeObserverDetail';
 
 /**

--- a/src/algorithms/hasSkippedObservations.ts
+++ b/src/algorithms/hasSkippedObservations.ts
@@ -1,4 +1,4 @@
-import { resizeObservers } from '../ResizeObserverController';
+import { resizeObservers } from '../utils/resizeObservers';
 import { ResizeObserverDetail } from '../ResizeObserverDetail';
 
 /**

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -1,0 +1,24 @@
+import { hasActiveObservations } from '../algorithms/hasActiveObservations';
+import { hasSkippedObservations } from '../algorithms/hasSkippedObservations';
+import { deliverResizeLoopError } from '../algorithms/deliverResizeLoopError';
+import { broadcastActiveObservations } from '../algorithms/broadcastActiveObservations';
+import { gatherActiveObservationsAtDepth } from '../algorithms/gatherActiveObservationsAtDepth';
+
+/**
+ * Runs through the algorithms and
+ * broadcasts and changes that are returned.
+ */
+const process = (): boolean => {
+  let depth = 0;
+  gatherActiveObservationsAtDepth(depth);
+  while (hasActiveObservations()) {
+    depth = broadcastActiveObservations();
+    gatherActiveObservationsAtDepth(depth);
+  }
+  if (hasSkippedObservations()) {
+    deliverResizeLoopError();
+  }
+  return depth > 0;
+}
+
+export { process };

--- a/src/utils/resizeObservers.ts
+++ b/src/utils/resizeObservers.ts
@@ -1,0 +1,5 @@
+import { ResizeObserverDetail } from '../ResizeObserverDetail';
+
+const resizeObservers: ResizeObserverDetail[] = [];
+
+export { resizeObservers };

--- a/src/utils/scheduler.ts
+++ b/src/utils/scheduler.ts
@@ -1,6 +1,10 @@
-import { process, isWatching } from '../ResizeObserverController';
+import { process } from './process';
 import { global } from './global';
 import { queueResizeObserver } from './queueResizeObserver';
+
+let watching = 0;
+
+const isWatching = (): boolean => !!watching;
 
 const CATCH_FRAMES = 60 / 5; // Fifth of a second
 
@@ -102,4 +106,10 @@ class Scheduler {
 
 const scheduler = new Scheduler();
 
-export { scheduler };
+const updateCount = (n: number): void => {
+  !watching && n > 0 && scheduler.start();
+  watching += n;
+  !watching && scheduler.stop();
+}
+
+export { scheduler, updateCount };


### PR DESCRIPTION
I'm using this package with [Rollup](https://github.com/rollup/rollup).
It works as expected, but Rollup warns there are 5 circular dependencies:

1. ResizeObserverController.ts → utils/scheduler.ts ↩︎
2. ResizeObserverController.ts → algorithms/hasActiveObservations.ts ↩︎
3. ResizeObserverController.ts → algorithms/hasSkippedObservations.ts ↩︎
4. ResizeObserverController.ts → algorithms/broadcastActiveObservations.ts ↩︎
5. ResizeObserverController.ts → algorithms/gatherActiveObservationsAtDepth.ts ↩︎

https://repl.it/@KeiIto/ResizeObserver (Press `run` to reproduce the warnings)

I hope to resolve these warnings. This PR moves some exports from ResizeObserverController.ts:

1. `resizeObservers` → `utils/resizeObservers.ts`.
2. `process` → `utils/process.ts`.
3. `isWatching` → `utils/scheduler.ts`.