### PR TITLE
Minor improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,11 @@
   "name": "@juggle/resize-observer",
   "version": "2.4.0",
   "description": "Polyfills the ResizeObserver API and supports box size options from the latest spec",
+  "type": "module",
   "main": "./lib/ResizeObserver.js",
   "module": "./lib/ResizeObserver.js",
   "source": "./lib/ResizeObserver.js",
+  "types": "./lib/ResizeObserver.d.ts",
   "files": [
     "lib/**/*.{js,ts}"
   ],

--- a/src/ResizeObserverController.ts
+++ b/src/ResizeObserverController.ts
@@ -11,6 +11,7 @@ import { hasSkippedObservations } from './algorithms/hasSkippedObservations';
 import { deliverResizeLoopError } from './algorithms/deliverResizeLoopError';
 import { broadcastActiveObservations } from './algorithms/broadcastActiveObservations';
 import { gatherActiveObservationsAtDepth } from './algorithms/gatherActiveObservationsAtDepth';
+import { ResizeObserverBoxOptions } from './ResizeObserverBoxOptions';
 
 const resizeObservers: ResizeObserverDetail[] = [];
 const observerMap = new Map();
@@ -64,7 +65,7 @@ class ResizeObserverController {
     if (observerMap.has(resizeObserver)) {
       const detail = observerMap.get(resizeObserver) as ResizeObserverDetail;
       if (getObservationIndex(detail.observationTargets, target) < 0) {
-        detail.observationTargets.push(new ResizeObservation(target, options && options.box));
+        detail.observationTargets.push(new ResizeObservation(target, options && options.box as ResizeObserverBoxOptions));
         updateCount(1);
         scheduler.schedule(); // Schedule next observation
       }

--- a/src/ResizeObserverOptions.ts
+++ b/src/ResizeObserverOptions.ts
@@ -2,12 +2,12 @@ import { ResizeObserverBoxOptions } from './ResizeObserverBoxOptions';
 
 /**
  * Options to be given to the resize observer,
- * when oberving a new element.
+ * when observing a new element.
  *
  * https://drafts.csswg.org/resize-observer-1/#dictdef-resizeobserveroptions
  */
 interface ResizeObserverOptions {
-  box: ResizeObserverBoxOptions | undefined;
+  box?: 'content-box' | 'border-box' | ResizeObserverBoxOptions;
 }
 
 export { ResizeObserverOptions };


### PR DESCRIPTION
- Sets package type to module, which may improve #82 in some cases.
- Adds [types] field to explicitly import declaration files, which closes #78.
- Improves usage in TypeScript, when setting box option.