### PR TITLE
Added Rollup, ESM and CJS builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage
 lib
 junit.xml
 .cache
+.rpt2_cache

--- a/package.json
+++ b/package.json
@@ -3,15 +3,15 @@
   "version": "2.5.0",
   "description": "Polyfills the ResizeObserver API and supports box size options from the latest spec",
   "type": "module",
-  "main": "./lib/ResizeObserver.js",
-  "module": "./lib/ResizeObserver.js",
+  "main": "lib/ResizeObserver.js",
+  "module": "./lib/ResizeObserver.esm.js",
   "source": "./lib/ResizeObserver.js",
-  "types": "./lib/ResizeObserver.d.ts",
+  "types": "lib/ResizeObserver.d.ts",
   "files": [
     "lib/**/*.{js,ts}"
   ],
   "scripts": {
-    "build": "rm -rf lib && tsc",
+    "build": "rm -rf lib && rollup -c",
     "build-docs": "rm -f docs/*.* && parcel build docs/src/index.html --out-dir docs --public-url ./",
     "ci-tests": "npm test -- --ci --runInBand && cat coverage/lcov.info | coveralls",
     "test": "npm run lint && jest --coverage",
@@ -62,6 +62,8 @@
     "jest-junit": "^6.4.0",
     "jsdom": "^15.1.1",
     "parcel-bundler": "^1.12.4",
+    "rollup": "^1.27.8",
+    "rollup-plugin-typescript2": "^0.25.3",
     "ts-jest": "^24.0.2",
     "typescript": "^3.5.2"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,19 @@
+import path from 'path'
+import typescript from 'rollup-plugin-typescript2'
+
+export default async () => {
+  return {
+    input: './src/ResizeObserver.ts',
+    output: [
+      {
+        format: 'cjs',
+        file: path.resolve(__dirname, 'lib', `ResizeObserver.js`),
+      },
+      {
+        format: 'es',
+        file: path.resolve(__dirname, 'lib', `ResizeObserver.esm.js`),
+      },
+    ],
+    plugins: [typescript()],
+  }
+}


### PR DESCRIPTION
This should close #82.

This maintains a default export and a named export of ResizeObserver, but provides both ESM and CJS versions.

Bundlers should detect the `__esModule` property and this shouldn't be a breaking change.