### PR TITLE
fix: queueMicroTask for older chrome variants

### DIFF
--- a/src/utils/queueMicroTask.ts
+++ b/src/utils/queueMicroTask.ts
@@ -7,10 +7,11 @@ const queueMicroTask = (callback: () => void): void => {
   // Create on request for SSR
   // ToDo: Look at changing this
   if (!trigger) {
+    let toggle = 0;
     const el = document.createTextNode('');
     const config = { characterData: true };
     new MutationObserver((): void => notify()).observe(el, config);
-    trigger = (): void => { el.textContent = ''; };
+    trigger = (): void => { el.textContent = `${toggle ? toggle-- : toggle++}`; };
   }
   callbacks.push(callback);
   trigger();


### PR DESCRIPTION
This fixes an issue where the scheduler would never run on older chromium variants due to differences with the MutationObserver's implementation.

Tested on:
*Chromium 45.0.2454.0 (64-bit)*