### PR TITLE
Allow custom global (window)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@juggle/resize-observer",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@juggle/resize-observer",
-  "version": "3.2.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anilanar/resize-observer",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Polyfills the ResizeObserver API and supports box size options from the latest spec",
   "main": "lib/exports/resize-observer.umd.js",
   "module": "lib/exports/resize-observer.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@juggle/resize-observer",
+  "name": "@anilanar/resize-observer",
   "version": "3.2.0",
   "description": "Polyfills the ResizeObserver API and supports box size options from the latest spec",
   "main": "lib/exports/resize-observer.umd.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anilanar/resize-observer",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Polyfills the ResizeObserver API and supports box size options from the latest spec",
   "main": "lib/exports/resize-observer.umd.js",
   "module": "lib/exports/resize-observer.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anilanar/resize-observer",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Polyfills the ResizeObserver API and supports box size options from the latest spec",
   "main": "lib/exports/resize-observer.umd.js",
   "module": "lib/exports/resize-observer.js",

--- a/src/ResizeObserver.ts
+++ b/src/ResizeObserver.ts
@@ -1,51 +1,77 @@
-import { ResizeObserverController } from './ResizeObserverController';
-import { ResizeObserverCallback } from './ResizeObserverCallback';
-import { ResizeObserverOptions } from './ResizeObserverOptions';
-import { isElement } from './utils/element';
+import { createResizeObserverController } from "./ResizeObserverController";
+import { ResizeObserverCallback } from "./ResizeObserverCallback";
+import { ResizeObserverOptions } from "./ResizeObserverOptions";
+import { isElement } from "./utils/element";
+import { unsafeGlobal } from "./utils/global";
+
+export interface ResizeObserver {
+  observe(target: Element, options?: ResizeObserverOptions): void;
+  unobserve(target: Element): void;
+  disconnect(): void;
+}
 
 /**
  * https://drafts.csswg.org/resize-observer-1/#resize-observer-interface
  */
-class ResizeObserver {
-
-  public constructor (callback: ResizeObserverCallback) {
-    if (arguments.length === 0) {
-      throw new TypeError(`Failed to construct 'ResizeObserver': 1 argument required, but only 0 present.`)
-    }
-    if (typeof callback !== 'function') {
-      throw new TypeError(`Failed to construct 'ResizeObserver': The callback provided as parameter 1 is not a function.`);
-    }
-    ResizeObserverController.connect(this, callback);
-  }
-
-  public observe (target: Element, options?: ResizeObserverOptions): void {
-    if (arguments.length === 0) {
-      throw new TypeError(`Failed to execute 'observe' on 'ResizeObserver': 1 argument required, but only 0 present.`)
-    }
-    if (!isElement(target)) {
-      throw new TypeError(`Failed to execute 'observe' on 'ResizeObserver': parameter 1 is not of type 'Element`);
-    }
-    ResizeObserverController.observe(this, target, options);
-  }
-
-  public unobserve (target: Element): void {
-    if (arguments.length === 0) {
-      throw new TypeError(`Failed to execute 'unobserve' on 'ResizeObserver': 1 argument required, but only 0 present.`)
-    }
-    if (!isElement(target)) {
-      throw new TypeError(`Failed to execute 'unobserve' on 'ResizeObserver': parameter 1 is not of type 'Element`);
-    }
-    ResizeObserverController.unobserve(this, target);
-  }
-
-  public disconnect (): void {
-    ResizeObserverController.disconnect(this);
-  }
-
-  public static toString (): string {
-    return 'function ResizeObserver () { [polyfill code] }';
-  }
-
+export interface ResizeObserverCls {
+  new (callback: ResizeObserverCallback): ResizeObserver;
+  prototype: ResizeObserver;
 }
 
-export { ResizeObserver };
+export const createResizeObserver = (global: Window): ResizeObserverCls => {
+  const ResizeObserverController = createResizeObserverController(global);
+
+  return class ResizeObserver {
+    public constructor(callback: ResizeObserverCallback) {
+      if (arguments.length === 0) {
+        throw new TypeError(
+          `Failed to construct 'ResizeObserver': 1 argument required, but only 0 present.`
+        );
+      }
+      if (typeof callback !== "function") {
+        throw new TypeError(
+          `Failed to construct 'ResizeObserver': The callback provided as parameter 1 is not a function.`
+        );
+      }
+      ResizeObserverController.connect(this, callback);
+    }
+
+    public observe(target: Element, options?: ResizeObserverOptions): void {
+      if (arguments.length === 0) {
+        throw new TypeError(
+          `Failed to execute 'observe' on 'ResizeObserver': 1 argument required, but only 0 present.`
+        );
+      }
+      if (!isElement(target)) {
+        throw new TypeError(
+          `Failed to execute 'observe' on 'ResizeObserver': parameter 1 is not of type 'Element`
+        );
+      }
+      ResizeObserverController.observe(this, target, options);
+    }
+
+    public unobserve(target: Element): void {
+      if (arguments.length === 0) {
+        throw new TypeError(
+          `Failed to execute 'unobserve' on 'ResizeObserver': 1 argument required, but only 0 present.`
+        );
+      }
+      if (!isElement(target)) {
+        throw new TypeError(
+          `Failed to execute 'unobserve' on 'ResizeObserver': parameter 1 is not of type 'Element`
+        );
+      }
+      ResizeObserverController.unobserve(this, target);
+    }
+
+    public disconnect(): void {
+      ResizeObserverController.disconnect(this);
+    }
+
+    public static toString(): string {
+      return "function ResizeObserver () { [polyfill code] }";
+    }
+  };
+};
+
+export const ResizeObserver = createResizeObserver(unsafeGlobal);

--- a/src/ResizeObserverController.ts
+++ b/src/ResizeObserverController.ts
@@ -1,63 +1,98 @@
-import { scheduler, updateCount } from './utils/scheduler';
+import { createScheduler } from "./utils/scheduler";
 
-import { ResizeObserver } from './ResizeObserver';
-import { ResizeObservation } from './ResizeObservation';
-import { ResizeObserverDetail } from './ResizeObserverDetail';
-import { ResizeObserverCallback } from './ResizeObserverCallback';
-import { ResizeObserverOptions } from './ResizeObserverOptions';
+import { ResizeObserver } from "./ResizeObserver";
+import { ResizeObservation } from "./ResizeObservation";
+import { ResizeObserverDetail } from "./ResizeObserverDetail";
+import { ResizeObserverCallback } from "./ResizeObserverCallback";
+import { ResizeObserverOptions } from "./ResizeObserverOptions";
 
-import { resizeObservers } from './utils/resizeObservers';
-import { ResizeObserverBoxOptions } from './ResizeObserverBoxOptions';
+import { resizeObservers } from "./utils/resizeObservers";
+import { ResizeObserverBoxOptions } from "./ResizeObserverBoxOptions";
 
 const observerMap = new WeakMap<ResizeObserver, ResizeObserverDetail>();
 
 // Helper to find the correct ResizeObservation, based on a target.
-const getObservationIndex = (observationTargets: ResizeObservation[], target: Element): number => {
-  for (let i = 0; i < observationTargets.length; i+= 1) {
+const getObservationIndex = (
+  observationTargets: ResizeObservation[],
+  target: Element
+): number => {
+  for (let i = 0; i < observationTargets.length; i += 1) {
     if (observationTargets[i].target === target) {
       return i;
     }
   }
   return -1;
+};
+
+interface ResizeObserverController {
+  connect(
+    resizeObserver: ResizeObserver,
+    callback: ResizeObserverCallback
+  ): void;
+  observe(
+    resizeObserver: ResizeObserver,
+    target: Element,
+    options?: ResizeObserverOptions
+  ): void;
+  unobserve(resizeObserver: ResizeObserver, target: Element): void;
+  disconnect(resizeObserver: ResizeObserver): void;
 }
 
 /**
  * Used as an interface for connecting resize observers.
  */
-class ResizeObserverController {
-  // Connects an observer to the controller.
-  public static connect (resizeObserver: ResizeObserver, callback: ResizeObserverCallback): void {
-    const detail = new ResizeObserverDetail(resizeObserver, callback);
-    observerMap.set(resizeObserver, detail);
-  }
-  // Informs the controller to watch a new target.
-  public static observe (resizeObserver: ResizeObserver, target: Element, options?: ResizeObserverOptions): void {
-    const detail = observerMap.get(resizeObserver) as ResizeObserverDetail;
-    const firstObservation = detail.observationTargets.length === 0;
-    if (getObservationIndex(detail.observationTargets, target) < 0) {
-      firstObservation && resizeObservers.push(detail);
-      detail.observationTargets.push(new ResizeObservation(target, options && options.box as ResizeObserverBoxOptions));
-      updateCount(1);
-      scheduler.schedule(); // Schedule next observation
-    }
-  }
-  // Informs the controller to stop watching a target.
-  public static unobserve (resizeObserver: ResizeObserver, target: Element): void {
-    const detail = observerMap.get(resizeObserver) as ResizeObserverDetail;
-    const index = getObservationIndex(detail.observationTargets, target);
-    const lastObservation = detail.observationTargets.length === 1;
-    if (index >= 0) {
-      lastObservation && resizeObservers.splice(resizeObservers.indexOf(detail), 1);
-      detail.observationTargets.splice(index, 1);
-      updateCount(-1);
-    }
-  }
-  // Informs the controller to disconnect an observer.
-  public static disconnect (resizeObserver: ResizeObserver): void {
-    const detail = observerMap.get(resizeObserver) as ResizeObserverDetail;
-    detail.observationTargets.slice().forEach((ot): void => this.unobserve(resizeObserver, ot.target));
-    detail.activeTargets.splice(0, detail.activeTargets.length);
-  }
-}
-
-export { ResizeObserverController };
+export const createResizeObserverController = (
+  global: Window
+): ResizeObserverController => {
+  const scheduler = createScheduler(global);
+  return {
+    // Connects an observer to the controller.
+    connect(
+      resizeObserver: ResizeObserver,
+      callback: ResizeObserverCallback
+    ): void {
+      const detail = new ResizeObserverDetail(resizeObserver, callback);
+      observerMap.set(resizeObserver, detail);
+    },
+    // Informs the controller to watch a new target.
+    observe(
+      resizeObserver: ResizeObserver,
+      target: Element,
+      options?: ResizeObserverOptions
+    ): void {
+      const detail = observerMap.get(resizeObserver) as ResizeObserverDetail;
+      const firstObservation = detail.observationTargets.length === 0;
+      if (getObservationIndex(detail.observationTargets, target) < 0) {
+        firstObservation && resizeObservers.push(detail);
+        detail.observationTargets.push(
+          new ResizeObservation(
+            target,
+            options && (options.box as ResizeObserverBoxOptions)
+          )
+        );
+        scheduler.updateCount(1);
+        scheduler.schedule(); // Schedule next observation
+      }
+    },
+    // Informs the controller to stop watching a target.
+    unobserve(resizeObserver: ResizeObserver, target: Element): void {
+      const detail = observerMap.get(resizeObserver) as ResizeObserverDetail;
+      const index = getObservationIndex(detail.observationTargets, target);
+      const lastObservation = detail.observationTargets.length === 1;
+      if (index >= 0) {
+        lastObservation &&
+          resizeObservers.splice(resizeObservers.indexOf(detail), 1);
+        detail.observationTargets.splice(index, 1);
+        scheduler.updateCount(-1);
+      }
+    },
+    // Informs the controller to disconnect an observer.
+    disconnect(resizeObserver: ResizeObserver): void {
+      const detail = observerMap.get(resizeObserver) as ResizeObserverDetail;
+      detail.observationTargets
+        .slice()
+        .forEach((ot): void => this.unobserve(resizeObserver, ot.target));
+      detail.activeTargets.splice(0, detail.activeTargets.length);
+    },
+  };
+};

--- a/src/algorithms/calculateBoxSize.ts
+++ b/src/algorithms/calculateBoxSize.ts
@@ -1,8 +1,8 @@
-import { ResizeObserverBoxOptions } from '../ResizeObserverBoxOptions';
-import { ResizeObserverSize } from '../ResizeObserverSize';
-import { DOMRectReadOnly } from '../DOMRectReadOnly';
-import { isSVG, isHidden } from '../utils/element';
-import { global } from '../utils/global';
+import { ResizeObserverBoxOptions } from "../ResizeObserverBoxOptions";
+import { ResizeObserverSize } from "../ResizeObserverSize";
+import { DOMRectReadOnly } from "../DOMRectReadOnly";
+import { isSVG, isHidden } from "../utils/element";
+import { unsafeGlobal } from "../utils/global";
 
 interface ResizeObserverSizeCollection {
   devicePixelContentBoxSize: ResizeObserverSize;
@@ -14,30 +14,39 @@ interface ResizeObserverSizeCollection {
 const cache = new WeakMap<Element, ResizeObserverSizeCollection>();
 const scrollRegexp = /auto|scroll/;
 const verticalRegexp = /^tb|vertical/;
-const IE = (/msie|trident/i).test(global.navigator && global.navigator.userAgent);
-const parseDimension = (pixel: string | null): number => parseFloat(pixel || '0');
+const IE = /msie|trident/i.test(
+  unsafeGlobal.navigator && unsafeGlobal.navigator.userAgent
+);
+const parseDimension = (pixel: string | null): number =>
+  parseFloat(pixel || "0");
 
 // Helper to generate and freeze a ResizeObserverSize
-const size = (inlineSize = 0, blockSize = 0, switchSizes = false): ResizeObserverSize => {
+const size = (
+  inlineSize = 0,
+  blockSize = 0,
+  switchSizes = false
+): ResizeObserverSize => {
   return Object.freeze({
     inlineSize: (switchSizes ? blockSize : inlineSize) || 0, // never return NaN
-    blockSize: (switchSizes ? inlineSize : blockSize) || 0   // never return NaN
+    blockSize: (switchSizes ? inlineSize : blockSize) || 0, // never return NaN
   });
-}
+};
 
 // Return this when targets are hidden
 const zeroBoxes = Object.freeze({
   devicePixelContentBoxSize: size(),
   borderBoxSize: size(),
   contentBoxSize: size(),
-  contentRect: new DOMRectReadOnly(0, 0, 0, 0)
-})
+  contentRect: new DOMRectReadOnly(0, 0, 0, 0),
+});
 
 /**
  * Gets all box sizes of an element.
  */
-const calculateBoxSizes = (target: Element, forceRecalculation = false): ResizeObserverSizeCollection => {
-
+const calculateBoxSizes = (
+  target: Element,
+  forceRecalculation = false
+): ResizeObserverSizeCollection => {
   // Check cache to prevent recalculating styles.
   if (cache.has(target) && !forceRecalculation) {
     return cache.get(target) as ResizeObserverSizeCollection;
@@ -52,17 +61,20 @@ const calculateBoxSizes = (target: Element, forceRecalculation = false): ResizeO
   const cs = getComputedStyle(target);
 
   // If element has an SVG box, handle things differently, using its bounding box.
-  const svg = isSVG(target) && (target as SVGElement).ownerSVGElement && (target as SVGGraphicsElement).getBBox();
+  const svg =
+    isSVG(target) &&
+    (target as SVGElement).ownerSVGElement &&
+    (target as SVGGraphicsElement).getBBox();
 
   // IE does not remove padding from width/height, when box-sizing is border-box.
-  const removePadding = !IE && cs.boxSizing === 'border-box';
+  const removePadding = !IE && cs.boxSizing === "border-box";
 
   // Switch sizes if writing mode is vertical.
-  const switchSizes = verticalRegexp.test(cs.writingMode || '');
+  const switchSizes = verticalRegexp.test(cs.writingMode || "");
 
   // Could the element have any scrollbars?
-  const canScrollVertically = !svg && scrollRegexp.test(cs.overflowY || '');
-  const canScrollHorizontally = !svg && scrollRegexp.test(cs.overflowX || '');
+  const canScrollVertically = !svg && scrollRegexp.test(cs.overflowY || "");
+  const canScrollHorizontally = !svg && scrollRegexp.test(cs.overflowX || "");
 
   // Calculate properties for creating boxes.
   const paddingTop = svg ? 0 : parseDimension(cs.paddingTop);
@@ -77,14 +89,40 @@ const calculateBoxSizes = (target: Element, forceRecalculation = false): ResizeO
   const verticalPadding = paddingTop + paddingBottom;
   const horizontalBorderArea = borderLeft + borderRight;
   const verticalBorderArea = borderTop + borderBottom;
-  const horizontalScrollbarThickness = !canScrollHorizontally ? 0 : (target as HTMLElement).offsetHeight - verticalBorderArea - target.clientHeight;
-  const verticalScrollbarThickness = !canScrollVertically ? 0 : (target as HTMLElement).offsetWidth - horizontalBorderArea - target.clientWidth;
-  const widthReduction = removePadding ? horizontalPadding + horizontalBorderArea : 0;
-  const heightReduction = removePadding ? verticalPadding + verticalBorderArea : 0;
-  const contentWidth = svg ? svg.width : parseDimension(cs.width) - widthReduction - verticalScrollbarThickness;
-  const contentHeight = svg ? svg.height : parseDimension(cs.height) - heightReduction - horizontalScrollbarThickness;
-  const borderBoxWidth = contentWidth + horizontalPadding + verticalScrollbarThickness + horizontalBorderArea;
-  const borderBoxHeight = contentHeight + verticalPadding + horizontalScrollbarThickness + verticalBorderArea;
+  const horizontalScrollbarThickness = !canScrollHorizontally
+    ? 0
+    : (target as HTMLElement).offsetHeight -
+      verticalBorderArea -
+      target.clientHeight;
+  const verticalScrollbarThickness = !canScrollVertically
+    ? 0
+    : (target as HTMLElement).offsetWidth -
+      horizontalBorderArea -
+      target.clientWidth;
+  const widthReduction = removePadding
+    ? horizontalPadding + horizontalBorderArea
+    : 0;
+  const heightReduction = removePadding
+    ? verticalPadding + verticalBorderArea
+    : 0;
+  const contentWidth = svg
+    ? svg.width
+    : parseDimension(cs.width) - widthReduction - verticalScrollbarThickness;
+  const contentHeight = svg
+    ? svg.height
+    : parseDimension(cs.height) -
+      heightReduction -
+      horizontalScrollbarThickness;
+  const borderBoxWidth =
+    contentWidth +
+    horizontalPadding +
+    verticalScrollbarThickness +
+    horizontalBorderArea;
+  const borderBoxHeight =
+    contentHeight +
+    verticalPadding +
+    horizontalScrollbarThickness +
+    verticalBorderArea;
 
   const boxes = Object.freeze({
     devicePixelContentBoxSize: size(
@@ -94,7 +132,12 @@ const calculateBoxSizes = (target: Element, forceRecalculation = false): ResizeO
     ),
     borderBoxSize: size(borderBoxWidth, borderBoxHeight, switchSizes),
     contentBoxSize: size(contentWidth, contentHeight, switchSizes),
-    contentRect: new DOMRectReadOnly(paddingLeft, paddingTop, contentWidth, contentHeight)
+    contentRect: new DOMRectReadOnly(
+      paddingLeft,
+      paddingTop,
+      contentWidth,
+      contentHeight
+    ),
   });
 
   cache.set(target, boxes);
@@ -104,11 +147,19 @@ const calculateBoxSizes = (target: Element, forceRecalculation = false): ResizeO
 
 /**
  * Calculates the observe box size of an element.
- * 
+ *
  * https://drafts.csswg.org/resize-observer-1/#calculate-box-size
  */
-const calculateBoxSize = (target: Element, observedBox: ResizeObserverBoxOptions, forceRecalculation?: boolean): ResizeObserverSize => {
-  const { borderBoxSize, contentBoxSize, devicePixelContentBoxSize } = calculateBoxSizes(target, forceRecalculation);
+const calculateBoxSize = (
+  target: Element,
+  observedBox: ResizeObserverBoxOptions,
+  forceRecalculation?: boolean
+): ResizeObserverSize => {
+  const {
+    borderBoxSize,
+    contentBoxSize,
+    devicePixelContentBoxSize,
+  } = calculateBoxSizes(target, forceRecalculation);
   switch (observedBox) {
     case ResizeObserverBoxOptions.DEVICE_PIXEL_CONTENT_BOX:
       return devicePixelContentBoxSize;

--- a/src/exports/resize-observer.ts
+++ b/src/exports/resize-observer.ts
@@ -1,2 +1,2 @@
-export { ResizeObserver } from "../ResizeObserver";
+export { createResizeObserver, ResizeObserver } from "../ResizeObserver";
 export { ResizeObserverEntry } from "../ResizeObserverEntry";

--- a/src/exports/resize-observer.ts
+++ b/src/exports/resize-observer.ts
@@ -1,2 +1,2 @@
-export { createResizeObserver, ResizeObserver } from "../ResizeObserver";
+export { createResizeObserver, ResizeObserver, ResizeObserverCls } from "../ResizeObserver";
 export { ResizeObserverEntry } from "../ResizeObserverEntry";

--- a/src/exports/resize-observer.ts
+++ b/src/exports/resize-observer.ts
@@ -1,2 +1,2 @@
-export { ResizeObserver } from '../ResizeObserver';
-export { ResizeObserverEntry } from '../ResizeObserverEntry';
+export { ResizeObserver } from "../ResizeObserver";
+export { ResizeObserverEntry } from "../ResizeObserverEntry";

--- a/src/utils/global.ts
+++ b/src/utils/global.ts
@@ -1,11 +1,11 @@
-import { ResizeObserver } from '../ResizeObserver';
-import { ResizeObserverEntry } from '../ResizeObserverEntry';
+import { ResizeObserverCls } from "../ResizeObserver";
+import { ResizeObserverEntry } from "../ResizeObserverEntry";
 
-type IsomorphicWindow = Window & {
-  ResizeObserver?: typeof ResizeObserver;
+export type IsomorphicWindow = Window & {
+  ResizeObserver?: ResizeObserverCls;
   ResizeObserverEntry?: typeof ResizeObserverEntry;
-}
+};
 
 /* istanbul ignore next */
-export const global: IsomorphicWindow =
-typeof window !== 'undefined' ? window : {} as unknown as Window;
+export const unsafeGlobal: IsomorphicWindow =
+  typeof window !== "undefined" ? window : (({} as unknown) as Window);

--- a/src/utils/scheduler.ts
+++ b/src/utils/scheduler.ts
@@ -1,65 +1,68 @@
-import { process } from './process';
-import { global } from './global';
-import { queueResizeObserver } from './queueResizeObserver';
-
-let watching = 0;
-
-const isWatching = (): boolean => !!watching;
+import { process } from "./process";
+import { queueResizeObserver } from "./queueResizeObserver";
+import { IsomorphicWindow, unsafeGlobal } from "./global";
 
 const CATCH_PERIOD = 250; // ms
 
-const observerConfig = { attributes: true, characterData: true, childList: true, subtree: true };
+const observerConfig = {
+  attributes: true,
+  characterData: true,
+  childList: true,
+  subtree: true,
+};
 
 const events = [
   // Global Resize
-  'resize',
+  "resize",
   // Global Load
-  'load',
+  "load",
   // Transitions & Animations
-  'transitionend',
-  'animationend',
-  'animationstart',
-  'animationiteration',
+  "transitionend",
+  "animationend",
+  "animationstart",
+  "animationiteration",
   // Interactions
-  'keyup',
-  'keydown',
-  'mouseup',
-  'mousedown',
-  'mouseover',
-  'mouseout',
-  'blur',
-  'focus'
+  "keyup",
+  "keydown",
+  "mouseup",
+  "mousedown",
+  "mouseover",
+  "mouseout",
+  "blur",
+  "focus",
 ];
 
-const time = (timeout = 0) => Date.now() + timeout;
-
-let scheduled = false;
 class Scheduler {
+  public stopped = true;
 
   private observer: MutationObserver | undefined;
   private listener: () => void;
-  public stopped = true;
+  private watching = 0;
+  private scheduled = false;
 
-  public constructor () {
+  public constructor(private global: IsomorphicWindow) {
     this.listener = (): void => this.schedule();
   }
 
-  private run (timeout = CATCH_PERIOD): void {
-    if (scheduled) {
+  isWatching(): boolean {
+    return !!this.watching;
+  }
+
+  private run(timeout = CATCH_PERIOD): void {
+    if (this.scheduled) {
       return;
     }
-    scheduled = true;
+    this.scheduled = true;
     const until = time(timeout);
     queueResizeObserver((): void => {
       let elementsHaveResized = false;
       try {
         // Process Calculations
         elementsHaveResized = process();
-      }
-      finally {
-        scheduled = false;
+      } finally {
+        this.scheduled = false;
         timeout = until - time();
-        if (!isWatching()) {
+        if (!this.isWatching()) {
           return;
         }
         // Have any changes happened?
@@ -78,41 +81,53 @@ class Scheduler {
     });
   }
 
-  public schedule (): void {
+  public updateCount(n: number): void {
+    !this.watching && n > 0 && this.start();
+    this.watching += n;
+    !this.watching && this.stop();
+  }
+
+  public schedule(): void {
     this.stop(); // Stop listening
     this.run(); // Run schedule
   }
 
-  private observe (): void {
-    const cb = (): void => this.observer && this.observer.observe(document.body, observerConfig);
+  private observe(): void {
+    const cb = (): void =>
+      this.observer && this.observer.observe(document.body, observerConfig);
     /* istanbul ignore next */
-    document.body ? cb() : global.addEventListener('DOMContentLoaded', cb);
+    document.body ? cb() : this.global.addEventListener("DOMContentLoaded", cb);
   }
 
-  public start (): void {
+  public start(): void {
     if (this.stopped) {
       this.stopped = false;
       this.observer = new MutationObserver(this.listener);
       this.observe();
-      events.forEach((name): void => global.addEventListener(name, this.listener, true));
+      events.forEach((name): void =>
+        this.global.addEventListener(name, this.listener, true)
+      );
     }
   }
 
-  public stop (): void {
+  public stop(): void {
     if (!this.stopped) {
       this.observer && this.observer.disconnect();
-      events.forEach((name): void => global.removeEventListener(name, this.listener, true));
+      events.forEach((name): void =>
+        this.global.removeEventListener(name, this.listener, true)
+      );
       this.stopped = true;
     }
   }
 }
 
-const scheduler = new Scheduler();
-
-const updateCount = (n: number): void => {
-  !watching && n > 0 && scheduler.start();
-  watching += n;
-  !watching && scheduler.stop();
+function time(timeout = 0) {
+  return Date.now() + timeout;
 }
 
-export { scheduler, updateCount };
+export const createScheduler = (global: IsomorphicWindow): Scheduler => {
+  return new Scheduler(global);
+};
+
+export const scheduler = createScheduler(unsafeGlobal);
+export const updateCount = scheduler.updateCount.bind(scheduler);

--- a/test/resize-observer-basic.test.ts
+++ b/test/resize-observer-basic.test.ts
@@ -1,21 +1,20 @@
-import './helpers/mutation-observer';
-import { ResizeObserver } from '../src/ResizeObserver';
-import { scheduler } from '../src/utils/scheduler';
-import { delay } from './helpers/delay';
-import './helpers/offset';
+import "./helpers/mutation-observer";
+import { ResizeObserver } from "../src/ResizeObserver";
+import { createScheduler } from "../src/utils/scheduler";
+import { delay } from "./helpers/delay";
+import "./helpers/offset";
 
-describe('Basics', (): void => {
-
+describe("Basics", (): void => {
   let el: HTMLElement;
   let ro: ResizeObserver | null;
 
   beforeEach((done): void => {
-    el = document.createElement('div');
-    el.style.width = '100px';
+    el = document.createElement("div");
+    el.style.width = "100px";
     document.body.appendChild(el);
     // Make sure it's a clean frame to run the test on
     requestAnimationFrame((): void => done());
-  })
+  });
 
   afterEach((): void => {
     while (document.body.firstElementChild) {
@@ -25,133 +24,159 @@ describe('Basics', (): void => {
       ro.disconnect();
       ro = null;
     }
-  })
+  });
 
-  test('console.log(ResizeObserver) should be prettified', (): void => {
-    expect(ResizeObserver.toString()).toBe('function ResizeObserver () { [polyfill code] }');
-  })
+  test("console.log(ResizeObserver) should be prettified", (): void => {
+    expect(ResizeObserver.toString()).toBe(
+      "function ResizeObserver () { [polyfill code] }"
+    );
+  });
 
-  test('Throw error when no callback is passed to constructor', (): void => {
+  test("Throw error when no callback is passed to constructor", (): void => {
     const fn = (): void => {
       // eslint-disable-next-line
       // @ts-ignore
       new ResizeObserver();
     };
-    expect(fn).toThrowError(`Failed to construct 'ResizeObserver': 1 argument required, but only 0 present.`);
-  })
+    expect(fn).toThrowError(
+      `Failed to construct 'ResizeObserver': 1 argument required, but only 0 present.`
+    );
+  });
 
-  test('Throw error when an invalid callback is passed to constructor', (): void => {
+  test("Throw error when an invalid callback is passed to constructor", (): void => {
     const fn = (): void => {
       // eslint-disable-next-line
       // @ts-ignore
       new ResizeObserver(1);
     };
-    expect(fn).toThrowError(`Failed to construct 'ResizeObserver': The callback provided as parameter 1 is not a function.`);
-  })
+    expect(fn).toThrowError(
+      `Failed to construct 'ResizeObserver': The callback provided as parameter 1 is not a function.`
+    );
+  });
 
-  test('Throw error when no target is passed to observe()', (): void => {
+  test("Throw error when no target is passed to observe()", (): void => {
     const fn = (): void => {
-      ro = new ResizeObserver((): void => { /* do nothing */ });
+      ro = new ResizeObserver((): void => {
+        /* do nothing */
+      });
       // eslint-disable-next-line
       // @ts-ignore
       ro.observe();
     };
-    expect(fn).toThrowError(`Failed to execute 'observe' on 'ResizeObserver': 1 argument required, but only 0 present.`);
-  })
+    expect(fn).toThrowError(
+      `Failed to execute 'observe' on 'ResizeObserver': 1 argument required, but only 0 present.`
+    );
+  });
 
-  test('Throw error when an invalid target is passed to observe()', (): void => {
+  test("Throw error when an invalid target is passed to observe()", (): void => {
     const fn = (): void => {
-      ro = new ResizeObserver((): void => { /* do nothing */ });
+      ro = new ResizeObserver((): void => {
+        /* do nothing */
+      });
       // eslint-disable-next-line
       // @ts-ignore
       ro.observe(1);
     };
-    expect(fn).toThrowError(`Failed to execute 'observe' on 'ResizeObserver': parameter 1 is not of type 'Element`);
-  })
+    expect(fn).toThrowError(
+      `Failed to execute 'observe' on 'ResizeObserver': parameter 1 is not of type 'Element`
+    );
+  });
 
-  test('Throw error when a null target is passed to observe()', (): void => {
+  test("Throw error when a null target is passed to observe()", (): void => {
     const fn = (): void => {
-      ro = new ResizeObserver((): void => { /* do nothing */ });
+      ro = new ResizeObserver((): void => {
+        /* do nothing */
+      });
       // eslint-disable-next-line
       // @ts-ignore
       ro.observe(null);
     };
-    expect(fn).toThrowError(`Failed to execute 'observe' on 'ResizeObserver': parameter 1 is not of type 'Element`);
-  })
+    expect(fn).toThrowError(
+      `Failed to execute 'observe' on 'ResizeObserver': parameter 1 is not of type 'Element`
+    );
+  });
 
-  test('Throw error when no target is passed to unobserve()', (): void => {
+  test("Throw error when no target is passed to unobserve()", (): void => {
     const fn = (): void => {
-      ro = new ResizeObserver((): void => { /* do nothing */ });
+      ro = new ResizeObserver((): void => {
+        /* do nothing */
+      });
       // eslint-disable-next-line
       // @ts-ignore
       ro.unobserve();
     };
-    expect(fn).toThrowError(`Failed to execute 'unobserve' on 'ResizeObserver': 1 argument required, but only 0 present.`);
-  })
+    expect(fn).toThrowError(
+      `Failed to execute 'unobserve' on 'ResizeObserver': 1 argument required, but only 0 present.`
+    );
+  });
 
-  test('Throw error when an invalid target is passed to unobserve()', (): void => {
+  test("Throw error when an invalid target is passed to unobserve()", (): void => {
     const fn = (): void => {
-      ro = new ResizeObserver((): void => { /* do nothing */ });
+      ro = new ResizeObserver((): void => {
+        /* do nothing */
+      });
       // eslint-disable-next-line
       // @ts-ignore
       ro.unobserve(1);
     };
-    expect(fn).toThrowError(`Failed to execute 'unobserve' on 'ResizeObserver': parameter 1 is not of type 'Element`);
-  })
+    expect(fn).toThrowError(
+      `Failed to execute 'unobserve' on 'ResizeObserver': parameter 1 is not of type 'Element`
+    );
+  });
 
-  test('Observer should not fire initially when size is 0,0', (done): void => {
+  test("Observer should not fire initially when size is 0,0", (done): void => {
     ro = new ResizeObserver((): void => {
       expect(false).toBe(true); // Should not fire
-    })
-    el.style.width = '0';
-    el.style.height = '0';
+    });
+    el.style.width = "0";
+    el.style.height = "0";
     ro.observe(el);
     delay(done);
-  })
+  });
 
-  test('Observer should not fire initially when display:none', (done): void => {
+  test("Observer should not fire initially when display:none", (done): void => {
     ro = new ResizeObserver((): void => {
       expect(false).toBe(true); // Should not fire
-    })
-    el.style.display = 'none';
+    });
+    el.style.display = "none";
     ro.observe(el);
     delay(done);
-  })
+  });
 
-  test('Observer should not fire initially when parent element is display:none', (done): void => {
+  test("Observer should not fire initially when parent element is display:none", (done): void => {
     ro = new ResizeObserver((): void => {
       expect(false).toBe(true); // Should not fire
-    })
-    const child = document.createElement('div');
-    el.style.display = 'none';
-    child.style.display = 'block';
+    });
+    const child = document.createElement("div");
+    el.style.display = "none";
+    child.style.display = "block";
     el.append(child);
-    expect(el.style.display).toBe('none');
-    expect(child.style.display).toBe('block');
+    expect(el.style.display).toBe("none");
+    expect(child.style.display).toBe("block");
     ro.observe(child);
     delay(done);
-  })
+  });
 
-  test('Observer should not fire when an element has no document', (done): void => {
+  test("Observer should not fire when an element has no document", (done): void => {
     el = el.cloneNode() as HTMLElement;
     ro = new ResizeObserver((): void => {
       expect(false).toBe(true); // Should not fire
-    })
-    el.style.width = '0';
-    el.style.height = '0';
+    });
+    el.style.width = "0";
+    el.style.height = "0";
     ro.observe(el);
     delay(done);
-  })
+  });
 
-  test('Observer callback.this should be observer', (done): void => {
+  test("Observer callback.this should be observer", (done): void => {
     ro = new ResizeObserver(function (this: ResizeObserver): void {
       expect(this).toBe(ro);
       done();
-    })
+    });
     ro.observe(el);
-  })
+  });
 
-  test('Observer should fire initially when element has size and display', (done): void => {
+  test("Observer should fire initially when element has size and display", (done): void => {
     ro = new ResizeObserver((entries): void => {
       expect(entries).toHaveLength(1);
       expect(entries[0].target).toBe(el);
@@ -159,14 +184,14 @@ describe('Basics', (): void => {
         top: 0,
         left: 0,
         width: 100,
-        height: 0
+        height: 0,
       });
       done();
-    })
+    });
     ro.observe(el);
-  })
+  });
 
-  test('Observer should only allow watching the same element once', (done): void => {
+  test("Observer should only allow watching the same element once", (done): void => {
     ro = new ResizeObserver((entries): void => {
       expect(entries).toHaveLength(1);
       expect(entries[0].target).toBe(el);
@@ -174,15 +199,15 @@ describe('Basics', (): void => {
         top: 0,
         left: 0,
         width: 100,
-        height: 0
+        height: 0,
       });
       done();
-    })
+    });
     ro.observe(el);
     ro.observe(el);
-  })
+  });
 
-  test('Observer should fire when element size changes', (done): void => {
+  test("Observer should fire when element size changes", (done): void => {
     ro = new ResizeObserver((entries): void => {
       expect(entries).toHaveLength(1);
       expect(entries[0].target).toBe(el);
@@ -190,20 +215,20 @@ describe('Basics', (): void => {
         top: 0,
         left: 0,
         width: 100,
-        height: 200
+        height: 200,
       });
       done();
-    })
-    el.style.width = '0';
-    el.style.height = '0';
+    });
+    el.style.width = "0";
+    el.style.height = "0";
     ro.observe(el);
     delay((): void => {
-      el.style.width = '100px';
-      el.style.height = '200px';
-    })
-  })
+      el.style.width = "100px";
+      el.style.height = "200px";
+    });
+  });
 
-  test('Observer should fire when the element\'s hidden state is toggled', (done): void => {
+  test("Observer should fire when the element's hidden state is toggled", (done): void => {
     let count = 0;
     ro = new ResizeObserver((entries): void => {
       count += 1;
@@ -213,22 +238,22 @@ describe('Basics', (): void => {
         top: 0,
         left: 0,
         width: count !== 2 ? 100 : 0,
-        height: 0
+        height: 0,
       });
       if (count === 3) {
         done();
       }
-    })
+    });
     ro.observe(el);
     delay((): void => {
-      el.style.display = 'none';
+      el.style.display = "none";
       delay((): void => {
-        el.style.removeProperty('display');
-      })
-    })
-  })
+        el.style.removeProperty("display");
+      });
+    });
+  });
 
-  test('Observer should fire when only the width changes', (done): void => {
+  test("Observer should fire when only the width changes", (done): void => {
     ro = new ResizeObserver((entries): void => {
       expect(entries).toHaveLength(1);
       expect(entries[0].target).toBe(el);
@@ -236,19 +261,19 @@ describe('Basics', (): void => {
         top: 0,
         left: 0,
         width: 100,
-        height: 0
+        height: 0,
       });
       done();
-    })
-    el.style.width = '0';
-    el.style.height = '0';
+    });
+    el.style.width = "0";
+    el.style.height = "0";
     ro.observe(el);
     delay((): void => {
-      el.style.width = '100px';
-    })
-  })
+      el.style.width = "100px";
+    });
+  });
 
-  test('Observer should fire when only the height changes', (done): void => {
+  test("Observer should fire when only the height changes", (done): void => {
     ro = new ResizeObserver((entries): void => {
       expect(entries).toHaveLength(1);
       expect(entries[0].target).toBe(el);
@@ -256,19 +281,19 @@ describe('Basics', (): void => {
         top: 0,
         left: 0,
         width: 0,
-        height: 100
+        height: 100,
       });
       done();
-    })
-    el.style.width = '0';
-    el.style.height = '0';
+    });
+    el.style.width = "0";
+    el.style.height = "0";
     ro.observe(el);
     delay((): void => {
-      el.style.height = '100px';
-    })
-  })
+      el.style.height = "100px";
+    });
+  });
 
-  test('Observer should handle padding on an element.', (done): void => {
+  test("Observer should handle padding on an element.", (done): void => {
     ro = new ResizeObserver((entries): void => {
       expect(entries).toHaveLength(1);
       expect(entries[0].target).toBe(el);
@@ -276,126 +301,126 @@ describe('Basics', (): void => {
         top: 1,
         left: 4,
         width: 100,
-        height: 200
+        height: 200,
       });
       done();
     });
-    el.style.width = '100px';
-    el.style.height = '200px';
-    el.style.padding = '1px 2px 3px 4px';
+    el.style.width = "100px";
+    el.style.height = "200px";
+    el.style.padding = "1px 2px 3px 4px";
     ro.observe(el);
-  })
+  });
 
-  test('Observer should handle vertical scrollbars on an element.', (done): void => {
+  test("Observer should handle vertical scrollbars on an element.", (done): void => {
     ro = new ResizeObserver((entries): void => {
       expect(entries).toHaveLength(1);
       expect(entries[0].target).toBe(el);
       expect(entries[0].contentRect).toMatchObject({
         width: 85,
-        height: 200
+        height: 200,
       });
       done();
     });
-    Object.defineProperty(el, 'offsetWidth', {
+    Object.defineProperty(el, "offsetWidth", {
       get: function (): number {
-        return 100
-      }
-    })
-    Object.defineProperty(el, 'offsetHeight', {
+        return 100;
+      },
+    });
+    Object.defineProperty(el, "offsetHeight", {
       get: function (): number {
-        return 200
-      }
-    })
-    Object.defineProperty(el, 'clientWidth', {
+        return 200;
+      },
+    });
+    Object.defineProperty(el, "clientWidth", {
       get: function (): number {
-        return 85
-      }
-    })
-    Object.defineProperty(el, 'clientHeight', {
+        return 85;
+      },
+    });
+    Object.defineProperty(el, "clientHeight", {
       get: function (): number {
-        return 200
-      }
-    })
-    el.style.overflowY = 'scroll';
-    el.style.width = '100px';
-    el.style.height = '200px';
+        return 200;
+      },
+    });
+    el.style.overflowY = "scroll";
+    el.style.width = "100px";
+    el.style.height = "200px";
     ro.observe(el);
-  })
+  });
 
-  test('Observer should handle horizontal scrollbars on an element.', (done): void => {
+  test("Observer should handle horizontal scrollbars on an element.", (done): void => {
     ro = new ResizeObserver((entries): void => {
       expect(entries).toHaveLength(1);
       expect(entries[0].target).toBe(el);
       expect(entries[0].contentRect).toMatchObject({
         width: 100,
-        height: 185
+        height: 185,
       });
       done();
     });
-    Object.defineProperty(el, 'offsetWidth', {
+    Object.defineProperty(el, "offsetWidth", {
       get: function (): number {
-        return 100
-      }
-    })
-    Object.defineProperty(el, 'offsetHeight', {
+        return 100;
+      },
+    });
+    Object.defineProperty(el, "offsetHeight", {
       get: function (): number {
-        return 200
-      }
-    })
-    Object.defineProperty(el, 'clientWidth', {
+        return 200;
+      },
+    });
+    Object.defineProperty(el, "clientWidth", {
       get: function (): number {
-        return 100
-      }
-    })
-    Object.defineProperty(el, 'clientHeight', {
+        return 100;
+      },
+    });
+    Object.defineProperty(el, "clientHeight", {
       get: function (): number {
-        return 185
-      }
-    })
-    el.style.overflowX = 'scroll';
-    el.style.width = '100px';
-    el.style.height = '200px';
+        return 185;
+      },
+    });
+    el.style.overflowX = "scroll";
+    el.style.width = "100px";
+    el.style.height = "200px";
     ro.observe(el);
-  })
+  });
 
-  test('Observer should handle horizontal and vertical scrollbars on an element.', (done): void => {
+  test("Observer should handle horizontal and vertical scrollbars on an element.", (done): void => {
     ro = new ResizeObserver((entries): void => {
       expect(entries).toHaveLength(1);
       expect(entries[0].target).toBe(el);
       expect(entries[0].contentRect).toMatchObject({
         width: 85,
-        height: 185
+        height: 185,
       });
       done();
     });
-    Object.defineProperty(el, 'offsetWidth', {
+    Object.defineProperty(el, "offsetWidth", {
       get: function (): number {
-        return 100
-      }
-    })
-    Object.defineProperty(el, 'offsetHeight', {
+        return 100;
+      },
+    });
+    Object.defineProperty(el, "offsetHeight", {
       get: function (): number {
-        return 200
-      }
-    })
-    Object.defineProperty(el, 'clientWidth', {
+        return 200;
+      },
+    });
+    Object.defineProperty(el, "clientWidth", {
       get: function (): number {
-        return 85
-      }
-    })
-    Object.defineProperty(el, 'clientHeight', {
+        return 85;
+      },
+    });
+    Object.defineProperty(el, "clientHeight", {
       get: function (): number {
-        return 185
-      }
-    })
-    el.style.overflowX = 'scroll';
-    el.style.overflowY = 'scroll';
-    el.style.width = '100px';
-    el.style.height = '200px';
+        return 185;
+      },
+    });
+    el.style.overflowX = "scroll";
+    el.style.overflowY = "scroll";
+    el.style.width = "100px";
+    el.style.height = "200px";
     ro.observe(el);
-  })
+  });
 
-  test('Observer should handle box-sizing and padding correctly.', (done): void => {
+  test("Observer should handle box-sizing and padding correctly.", (done): void => {
     ro = new ResizeObserver((entries): void => {
       expect(entries).toHaveLength(1);
       expect(entries[0].target).toBe(el);
@@ -403,26 +428,26 @@ describe('Basics', (): void => {
         top: 1,
         left: 4,
         width: 94,
-        height: 196
+        height: 196,
       });
       done();
     });
-    el.style.width = '100px';
-    el.style.height = '200px';
-    el.style.padding = '1px 2px 3px 4px';
-    el.style.boxSizing = 'border-box';
+    el.style.width = "100px";
+    el.style.height = "200px";
+    el.style.padding = "1px 2px 3px 4px";
+    el.style.boxSizing = "border-box";
     ro.observe(el);
-  })
+  });
 
-  test('Observer should fire when text content changes', (done): void => {
-    ro = new ResizeObserver((): void => done())
+  test("Observer should fire when text content changes", (done): void => {
+    ro = new ResizeObserver((): void => done());
     ro.observe(el);
     delay((): void => {
-      el.textContent = 'Hello';
-    })
-  })
+      el.textContent = "Hello";
+    });
+  });
 
-  test('Observer should unobserve elements correctly.', (done): void => {
+  test("Observer should unobserve elements correctly.", (done): void => {
     const el2 = el.cloneNode() as HTMLElement;
     document.body.appendChild(el2);
     ro = new ResizeObserver((entries, observer): void => {
@@ -434,9 +459,9 @@ describe('Basics', (): void => {
     ro.observe(el);
     ro.observe(el2);
     ro.unobserve(el2);
-  })
+  });
 
-  test('Observer should allow trying to unobserve multiple times.', (done): void => {
+  test("Observer should allow trying to unobserve multiple times.", (done): void => {
     const el2 = el.cloneNode() as HTMLElement;
     document.body.appendChild(el2);
     ro = new ResizeObserver((entries, observer): void => {
@@ -449,18 +474,18 @@ describe('Basics', (): void => {
     ro.observe(el2);
     ro.unobserve(el2);
     ro.unobserve(el2);
-  })
+  });
 
-  test('Observer should disconnect correctly.', (done): void => {
+  test("Observer should disconnect correctly.", (done): void => {
     ro = new ResizeObserver((): void => {
       expect(false).toBe(true); // Should not fire
     });
     ro.observe(el);
     ro.disconnect();
     delay(done);
-  })
+  });
 
-  test('Observer should allow trying to disconnect multiple times.', (done): void => {
+  test("Observer should allow trying to disconnect multiple times.", (done): void => {
     ro = new ResizeObserver((): void => {
       expect(false).toBe(true); // Should not fire
     });
@@ -468,18 +493,18 @@ describe('Basics', (): void => {
     ro.disconnect();
     ro.disconnect();
     delay(done);
-  })
+  });
 
-  test('Observer should observe after a disconnect.', (done): void => {
+  test("Observer should observe after a disconnect.", (done): void => {
     ro = new ResizeObserver((): void => {
       done();
     });
     ro.observe(el);
     ro.disconnect();
     ro.observe(el);
-  })
+  });
 
-  test('Observer should allow disconnect and unobserve to be called.', (done): void => {
+  test("Observer should allow disconnect and unobserve to be called.", (done): void => {
     ro = new ResizeObserver((): void => {
       expect(false).toBe(true); // Should not fire
     });
@@ -487,14 +512,20 @@ describe('Basics', (): void => {
     ro.disconnect();
     ro.unobserve(el);
     delay(done);
-  })
+  });
 
-  test('Observer should fire resize loop errors.', (done): void => {
-    window.addEventListener('error', (e): void => {
-      expect(e.type).toBe('error');
-      expect(e.message).toBe('ResizeObserver loop completed with undelivered notifications.');
-      done();
-    }, { once: true });
+  test("Observer should fire resize loop errors.", (done): void => {
+    window.addEventListener(
+      "error",
+      (e): void => {
+        expect(e.type).toBe("error");
+        expect(e.message).toBe(
+          "ResizeObserver loop completed with undelivered notifications."
+        );
+        done();
+      },
+      { once: true }
+    );
     ro = new ResizeObserver((entries): void => {
       entries.forEach((entry): void => {
         const target = entry.target as HTMLElement;
@@ -502,46 +533,54 @@ describe('Basics', (): void => {
       });
     });
     ro.observe(el);
-  })
+  });
 
-  test('Observer should return itself in the callback.', (done): void => {
+  test("Observer should return itself in the callback.", (done): void => {
     ro = new ResizeObserver((entries, observer): void => {
       expect(observer).toBe(observer);
       done();
     });
     ro.observe(el);
-  })
+  });
 
-  test('Calculations should be run after all other raf callbacks have been fired.', (done): void => {
+  test("Calculations should be run after all other raf callbacks have been fired.", (done): void => {
     ro = new ResizeObserver((entries): void => {
       expect(entries[0].contentRect.width).toBe(2000);
       done();
     });
     ro.observe(el);
     requestAnimationFrame((): void => {
-      el.style.width = '2000px';
+      el.style.width = "2000px";
     });
-  })
+  });
 
-  test('Scheduler should start and stop itself correctly.', (done): void => {
-    // Stopped at start
+  test("Scheduler should start and stop itself correctly.", (done): void => {
+    const scheduler = createScheduler(window);
     expect(scheduler.stopped).toBe(true);
-    ro = new ResizeObserver((): void => { /* do nothing */ });
-    // Creating an observer should not start the scheduler
+    scheduler.updateCount(1);
+    expect(scheduler.stopped).toBe(false);
+
+    scheduler.schedule();
     expect(scheduler.stopped).toBe(true);
-    ro.observe(el);
-    // Observing will trigger a schedule, however,
-    // it will not start listening for other changes until
-    // the processing is complete
-    expect(scheduler.stopped).toBe(true);
-    // After ~1s the observer should stop polling and move back to events
+
+    // Around 100ms later, scheduler should be still stopped
+    setTimeout((): void => {
+      expect(scheduler.stopped).toBe(true);
+    }, 100);
+
+    // Around 250ms later, scheduler starts again
     setTimeout((): void => {
       expect(scheduler.stopped).toBe(false);
+
+      scheduler.updateCount(-1);
+      expect(scheduler.stopped).toBe(true);
+
       done();
-    }, 1500);
-  })
+    }, 300);
+  });
 
-  test('Scheduler should handle multiple starts and stops.', (): void => {
+  test("Scheduler should handle multiple starts and stops.", (): void => {
+    const scheduler = createScheduler(window);
     expect(scheduler.stopped).toBe(true);
     scheduler.start();
     expect(scheduler.stopped).toBe(false);
@@ -551,6 +590,5 @@ describe('Basics', (): void => {
     expect(scheduler.stopped).toBe(true);
     scheduler.stop();
     expect(scheduler.stopped).toBe(true);
-  })
-
-})
+  });
+});


### PR DESCRIPTION
This is something we will use @userlike, not sure if you would be interested in this which is a non-breaking change. If so, we can work on merging this.

It introduces `const createResizeObserver: (global: Window) => ResizeObserverCls` and does some changes on the scheduler so that it is less "global". There are other minor changes such as `ResizeObserverCls` as an interface.

Our use case for this is observing changes inside an iframe.

I'm already aware that you have plans to introduce "observed root list" to have better shadow dom support. But until then, perhaps this is not a bad solution because this:

1) is a non breaking change
2) doesn't really conflict with such plans
3) is already an improvement for certain use cases
4) `createResizeObserver(global: Window): ResizeObserverCls` API surface is easily maintainable long-term.

(Sorry for formatting, prettier user here. Turn "whitespace changes" off. Can undo formatting if we agree on merging this).

Also, you can test it with `@anilanar/resize-observer` if you wish, which is published on npm.