### PR TITLE
Freeze arrays of reported sizes

### DIFF
--- a/src/DOMRectReadOnly.ts
+++ b/src/DOMRectReadOnly.ts
@@ -1,3 +1,5 @@
+import { freeze } from './utils/freeze';
+
 interface Rectangle {
   readonly x: number;
   readonly y: number;
@@ -38,7 +40,7 @@ class DOMRectReadOnly {
     this.left = this.x;
     this.bottom = this.top + this.height;
     this.right = this.left + this.width;
-    return Object.freeze(this);
+    return freeze(this);
   }
   public toJSON (): DOMRectJSON {
     const { x, y, top, right, bottom, left, width, height } = this;

--- a/src/ResizeObservation.ts
+++ b/src/ResizeObservation.ts
@@ -16,7 +16,7 @@ class ResizeObservation {
 
   public target: Element;
   public observedBox: ResizeObserverBoxOptions;
-  public lastReportedSize: ResizeObserverSize;
+  public lastReportedSize: ResizeObserverSize; // Todo: update to FrozenArray
 
   public constructor (target: Element, observedBox?: ResizeObserverBoxOptions) {
     this.target = target;

--- a/src/ResizeObserverEntry.ts
+++ b/src/ResizeObserverEntry.ts
@@ -8,16 +8,16 @@ import { calculateBoxSizes } from './algorithms/calculateBoxSize';
 class ResizeObserverEntry {
   public target: Element;
   public contentRect: DOMRectReadOnly;
-  public borderBoxSize: ResizeObserverSize[];
-  public contentBoxSize: ResizeObserverSize[];
-  public devicePixelContentBoxSize: ResizeObserverSize[];
+  public borderBoxSize: readonly ResizeObserverSize[];
+  public contentBoxSize: readonly ResizeObserverSize[];
+  public devicePixelContentBoxSize: readonly ResizeObserverSize[];
   public constructor (target: Element) {
     const boxes = calculateBoxSizes(target);
     this.target = target;
     this.contentRect = boxes.contentRect;
-    this.borderBoxSize = [boxes.borderBoxSize];
-    this.contentBoxSize = [boxes.contentBoxSize];
-    this.devicePixelContentBoxSize = [boxes.devicePixelContentBoxSize];
+    this.borderBoxSize = Object.freeze([boxes.borderBoxSize]);
+    this.contentBoxSize = Object.freeze([boxes.contentBoxSize]);
+    this.devicePixelContentBoxSize = Object.freeze([boxes.devicePixelContentBoxSize]);
   }
 }
 

--- a/src/ResizeObserverEntry.ts
+++ b/src/ResizeObserverEntry.ts
@@ -1,6 +1,7 @@
 import { DOMRectReadOnly } from './DOMRectReadOnly';
 import { ResizeObserverSize } from './ResizeObserverSize';
 import { calculateBoxSizes } from './algorithms/calculateBoxSize';
+import { freeze } from './utils/freeze';
 
 /**
  * https://drafts.csswg.org/resize-observer-1/#resize-observer-entry-interface
@@ -15,9 +16,9 @@ class ResizeObserverEntry {
     const boxes = calculateBoxSizes(target);
     this.target = target;
     this.contentRect = boxes.contentRect;
-    this.borderBoxSize = Object.freeze([boxes.borderBoxSize]);
-    this.contentBoxSize = Object.freeze([boxes.contentBoxSize]);
-    this.devicePixelContentBoxSize = Object.freeze([boxes.devicePixelContentBoxSize]);
+    this.borderBoxSize = freeze([boxes.borderBoxSize]);
+    this.contentBoxSize = freeze([boxes.contentBoxSize]);
+    this.devicePixelContentBoxSize = freeze([boxes.devicePixelContentBoxSize]);
   }
 }
 

--- a/src/ResizeObserverSize.ts
+++ b/src/ResizeObserverSize.ts
@@ -6,7 +6,7 @@ import { freeze } from './utils/freeze';
  * https://drafts.csswg.org/resize-observer-1/#resizeobserversize 
  */
 class ResizeObserverSize {
-  readonly inlineSize:  number;
+  readonly inlineSize: number;
   readonly blockSize: number;
   constructor (inlineSize: number, blockSize: number) {
     this.inlineSize = inlineSize;

--- a/src/ResizeObserverSize.ts
+++ b/src/ResizeObserverSize.ts
@@ -1,11 +1,18 @@
+import { freeze } from './utils/freeze';
+
 /**
  * Size of a specific box.
  * 
  * https://drafts.csswg.org/resize-observer-1/#resizeobserversize 
  */
-interface ResizeObserverSize {
-  readonly inlineSize: number;
+class ResizeObserverSize {
+  readonly inlineSize:  number;
   readonly blockSize: number;
+  constructor (inlineSize: number, blockSize: number) {
+    this.inlineSize = inlineSize;
+    this.blockSize = blockSize;
+    freeze(this);
+  }
 }
 
 export { ResizeObserverSize };

--- a/src/algorithms/calculateBoxSize.ts
+++ b/src/algorithms/calculateBoxSize.ts
@@ -2,6 +2,7 @@ import { ResizeObserverBoxOptions } from '../ResizeObserverBoxOptions';
 import { ResizeObserverSize } from '../ResizeObserverSize';
 import { DOMRectReadOnly } from '../DOMRectReadOnly';
 import { isSVG, isHidden } from '../utils/element';
+import { freeze } from '../utils/freeze';
 import { global } from '../utils/global';
 
 interface ResizeObserverSizeCollection {
@@ -19,14 +20,14 @@ const parseDimension = (pixel: string | null): number => parseFloat(pixel || '0'
 
 // Helper to generate and freeze a ResizeObserverSize
 const size = (inlineSize = 0, blockSize = 0, switchSizes = false): ResizeObserverSize => {
-  return Object.freeze({
-    inlineSize: (switchSizes ? blockSize : inlineSize) || 0, // never return NaN
-    blockSize: (switchSizes ? inlineSize : blockSize) || 0   // never return NaN
-  });
+  return new ResizeObserverSize(
+    (switchSizes ? blockSize : inlineSize) || 0,
+    (switchSizes ? inlineSize : blockSize) || 0
+  );
 }
 
 // Return this when targets are hidden
-const zeroBoxes = Object.freeze({
+const zeroBoxes = freeze({
   devicePixelContentBoxSize: size(),
   borderBoxSize: size(),
   contentBoxSize: size(),
@@ -86,7 +87,7 @@ const calculateBoxSizes = (target: Element, forceRecalculation = false): ResizeO
   const borderBoxWidth = contentWidth + horizontalPadding + verticalScrollbarThickness + horizontalBorderArea;
   const borderBoxHeight = contentHeight + verticalPadding + horizontalScrollbarThickness + verticalBorderArea;
 
-  const boxes = Object.freeze({
+  const boxes = freeze({
     devicePixelContentBoxSize: size(
       Math.round(contentWidth * devicePixelRatio),
       Math.round(contentHeight * devicePixelRatio),

--- a/src/exports/resize-observer.ts
+++ b/src/exports/resize-observer.ts
@@ -1,2 +1,3 @@
 export { ResizeObserver } from '../ResizeObserver';
 export { ResizeObserverEntry } from '../ResizeObserverEntry';
+export { ResizeObserverSize } from '../ResizeObserverSize';

--- a/src/utils/freeze.ts
+++ b/src/utils/freeze.ts
@@ -1,0 +1,1 @@
+export const freeze = <T> (obj: T): Readonly<T> => Object.freeze(obj);

--- a/src/utils/global.ts
+++ b/src/utils/global.ts
@@ -1,9 +1,11 @@
 import { ResizeObserver } from '../ResizeObserver';
 import { ResizeObserverEntry } from '../ResizeObserverEntry';
+import { ResizeObserverSize } from '../ResizeObserverSize';
 
 type IsomorphicWindow = Window & {
   ResizeObserver?: typeof ResizeObserver;
   ResizeObserverEntry?: typeof ResizeObserverEntry;
+  ResizeObserverSize?: typeof ResizeObserverSize;
 }
 
 /* istanbul ignore next */


### PR DESCRIPTION
This uses `Object.freeze` to return readonly arrays when reporting sizes to the observer callback.