### PR TITLE
fix: check for element in normal scope first

### DIFF
--- a/src/utils/element.ts
+++ b/src/utils/element.ts
@@ -14,7 +14,8 @@ const isHidden = (target: Element): boolean => {
 // Checks if an object is an Element
 const isElement = (obj: unknown): boolean => {
   const scope = (obj as Element)?.ownerDocument?.defaultView;
-  return !!(scope && obj instanceof (scope as unknown as typeof globalThis).Element);
+  return !!(scope && (obj instanceof (scope as unknown as typeof globalThis).Element ||
+   obj instanceof Element));
 };
 
 const isReplacedElement = (target: Element): boolean => {

--- a/src/utils/element.ts
+++ b/src/utils/element.ts
@@ -14,8 +14,7 @@ const isHidden = (target: Element): boolean => {
 // Checks if an object is an Element
 const isElement = (obj: unknown): boolean => {
   const scope = (obj as Element)?.ownerDocument?.defaultView;
-  return !!(scope && (obj instanceof (scope as unknown as typeof globalThis).Element ||
-   obj instanceof Element));
+  return !!(scope && (obj instanceof Element || obj instanceof (scope as unknown as typeof globalThis).Element));
 };
 
 const isReplacedElement = (target: Element): boolean => {

--- a/src/utils/element.ts
+++ b/src/utils/element.ts
@@ -14,7 +14,7 @@ const isHidden = (target: Element): boolean => {
 // Checks if an object is an Element
 const isElement = (obj: unknown): boolean => {
   if (obj instanceof Element) {
-    return true
+    return true;
   }
   const scope = (obj as Element)?.ownerDocument?.defaultView;
   return !!(scope && obj instanceof (scope as unknown as typeof globalThis).Element);

--- a/src/utils/element.ts
+++ b/src/utils/element.ts
@@ -13,8 +13,11 @@ const isHidden = (target: Element): boolean => {
 
 // Checks if an object is an Element
 const isElement = (obj: unknown): boolean => {
+  if (obj instanceof Element) {
+    return true
+  }
   const scope = (obj as Element)?.ownerDocument?.defaultView;
-  return !!(scope && (obj instanceof Element || obj instanceof (scope as unknown as typeof globalThis).Element));
+  return !!(scope && obj instanceof (scope as unknown as typeof globalThis).Element);
 };
 
 const isReplacedElement = (target: Element): boolean => {


### PR DESCRIPTION
Turns out in chrome the instance of elements are different in normal `window` vs elements inside `iframe`.

So, in this example https://codesandbox.io/s/wonderful-water-64s21 where all elements are inside portal. So, the scope of `obj` can be checked using `scope.Element`. But in this example https://codesandbox.io/s/observer-330-ucif1 the elements are created in global window but added to iframe dynamically. So, they both are not the same according to chrome.

Repo with the above check enabled --> https://github.com/JayaKrishnaNamburu/chrome-observer-bug

To compare with `Element` when `scope.Element` fails as fall back can solve the issue 😄
To extend check we can even do `obj.nodeType` because element nodes are `1`. But i am not sure about the observer scope, to which type of elements can one add a `ResizeObserver`.
https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType#constants