### PR TITLE
fix `process` global conflict in node.js

### DIFF
--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -8,7 +8,7 @@ import { gatherActiveObservationsAtDepth } from '../algorithms/gatherActiveObser
  * Runs through the algorithms and
  * broadcasts and changes that are returned.
  */
-const process = (): boolean => {
+const processAlgorithm = (): boolean => {
   let depth = 0;
   gatherActiveObservationsAtDepth(depth);
   while (hasActiveObservations()) {
@@ -21,4 +21,4 @@ const process = (): boolean => {
   return depth > 0;
 }
 
-export { process };
+export { processAlgorithm as process };


### PR DESCRIPTION
Hey, bro, there is a strange problem,`process` is a global var in node.js, in some case, it cause conflict:

<img width="1415" alt="Screenshot 2023-04-30 at 10 33 15" src="https://user-images.githubusercontent.com/20496444/235332816-36898689-ae59-45d6-8641-ca5c777c6375.png">

dist: 
<img width="667" alt="Screenshot 2023-04-30 at 10 34 10" src="https://user-images.githubusercontent.com/20496444/235332819-62594b05-9c9c-4003-88a5-3d57183a96f3.png">
